### PR TITLE
Add limits flags to Darkvision

### DIFF
--- a/scripts/macros/spells/darkness.js
+++ b/scripts/macros/spells/darkness.js
@@ -4,19 +4,33 @@ async function darknessItem({speaker, actor, token, character, item, args, scope
     if (!workflow.templateId) return;
     let template = canvas.scene.collections.templates.get(workflow.templateId);
     if (!template) return;
-    await template.setFlag('chris-premades', 'spell.darkness', true);
-    await template.setFlag('limits', 'sight', {
-      basicSight: {
-        range: 0,
-        enabled: true,
-      },
-      lightPerception: {
-        range: 0,
-        enabled: true,
-      },
-      devilsSight: {
-        range: null,
-        enabled: true,
+    await template.update({
+      flags: {
+        'chris-premades': {
+          spell: {
+            darkness: true,
+          },
+        },
+        'limits': {
+          sight: {
+            basicSight: {
+              range: 0,
+              enabled: true,
+            },
+            lightPerception: {
+              range: 0,
+              enabled: true,
+            },
+            devilsSight: {
+              range: null,
+              enabled: true,
+            },
+          },
+          light: {
+            enabled: true,
+            range: 0
+          }
+        },
       },
     });
     let attachToken = await chris.dialog('Attach to self?', [['Yes', true], ['No', false]]) || false;

--- a/scripts/macros/spells/darkness.js
+++ b/scripts/macros/spells/darkness.js
@@ -11,25 +11,17 @@ async function darknessItem({speaker, actor, token, character, item, args, scope
             darkness: true,
           },
         },
-        'limits': {
+        limits: {
           sight: {
-            basicSight: {
-              range: 0,
-              enabled: true,
-            },
-            lightPerception: {
-              range: 0,
-              enabled: true,
-            },
-            devilsSight: {
-              range: null,
-              enabled: true,
-            },
+            basicSight: { enabled: true, range: 0 }, // Darkvision
+            ghostlyGaze: { enabled: true, range: 0 }, // Ghostly Gaze
+            lightPerception: { enabled: true, range: 0 }, // Light Perception
           },
-          light: {
-            enabled: true,
-            range: 0
-          }
+          light: { enabled: true, range: 0 },
+        },
+        walledtemplates: {
+            wallRestriction: "move",
+            wallsBlock: "recurse",
         },
       },
     });

--- a/scripts/macros/spells/darkness.js
+++ b/scripts/macros/spells/darkness.js
@@ -5,6 +5,20 @@ async function darknessItem({speaker, actor, token, character, item, args, scope
     let template = canvas.scene.collections.templates.get(workflow.templateId);
     if (!template) return;
     await template.setFlag('chris-premades', 'spell.darkness', true);
+    await template.setFlag('limits', 'sight', {
+      basicSight: {
+        range: 0,
+        enabled: true,
+      },
+      lightPerception: {
+        range: 0,
+        enabled: true,
+      },
+      devilsSight: {
+        range: null,
+        enabled: true,
+      },
+    });
     let attachToken = await chris.dialog('Attach to self?', [['Yes', true], ['No', false]]) || false;
     if (!attachToken) return;
     let tokenObject = workflow.token;


### PR DESCRIPTION
Adds a flag to the darkness template that blocks light perception and darkvision if the limits module is installed.