### PR TITLE
Add limits / walled templates flags certain templates

### DIFF
--- a/scripts/macros/monsterFeatures/feySpirit/tricksy.js
+++ b/scripts/macros/monsterFeatures/feySpirit/tricksy.js
@@ -3,7 +3,40 @@ export async function tricksy({speaker, actor, token, character, item, args, sco
     if (!workflow.templateId) return;
     let template = canvas.scene.collections.templates.get(workflow.templateId);
     if (!template) return;
-    await template.setFlag('chris-premades', 'spell.darkness', true);
+    await template.update({
+        'flags': {
+            'chris-premades': {
+                'spell': {
+                    'darkness': true
+                }
+            },
+            'limits': {
+                'sight': {
+                    'basicSight': {
+                        'enabled': true,
+                        'range': 0
+                    },
+                    'ghostlyGaze': {
+                        'enabled': true,
+                        'range': 0
+                    },
+                    'lightPerception': {
+                        'enabled': true,
+                        'range': 0
+                    }
+                },
+                'light': {
+                    'enabled': true,
+                    'range': 0
+                }
+            },
+            'walledtemplates': {
+                'wallRestriction': 'move',
+                'wallsBlock': 'recurse'
+            }
+        }
+    });
+
     let effect = chris.findEffect(workflow.actor, workflow.item.name + ' Template');
     if (!effect) return;
     if (!chris.inCombat()) return;

--- a/scripts/macros/spells/fogCloud.js
+++ b/scripts/macros/spells/fogCloud.js
@@ -21,11 +21,26 @@ async function item({speaker, actor, token, character, item, args, scope, workfl
             },
             'limits': {
                 'sight': {
-                    'blindsight': { 'enabled': true, 'range': 0 }, // Blindsight
-                    'basicSight': { 'enabled': true, 'range': 0 }, // Darkvision
-                    'devilsSight': { 'enabled': true, 'range': 0 }, // Devil's Sight
-                    'lightPerception': { 'enabled': true, 'range': 0 }, // Light Perception
-                    'seeAll': { 'enabled': true, 'range': 0 }, // Truesight
+                    'blindsight': {
+                        'enabled': true,
+                        'range': 0
+                    },
+                    'basicSight': {
+                        'enabled': true,
+                        'range': 0
+                    },
+                    'devilsSight': {
+                        'enabled': true,
+                        'range': 0
+                    },
+                    'lightPerception': {
+                        'enabled': true,
+                        'range': 0
+                    },
+                    'seeAll': {
+                        'enabled': true,
+                        'range': 0
+                    },
                 },
             },
             'walledtemplates': {

--- a/scripts/macros/spells/fogCloud.js
+++ b/scripts/macros/spells/fogCloud.js
@@ -18,7 +18,20 @@ async function item({speaker, actor, token, character, item, args, scope, workfl
                 'spell': {
                     'fogCloud': true
                 }
-            }
+            },
+            'limits': {
+                'sight': {
+                    'blindsight': { 'enabled': true, 'range': 0 }, // Blindsight
+                    'basicSight': { 'enabled': true, 'range': 0 }, // Darkvision
+                    'devilsSight': { 'enabled': true, 'range': 0 }, // Devil's Sight
+                    'lightPerception': { 'enabled': true, 'range': 0 }, // Light Perception
+                    'seeAll': { 'enabled': true, 'range': 0 }, // Truesight
+                },
+            },
+            'walledtemplates': {
+                'wallRestriction': "move",
+                'wallsBlock': "recurse",
+            },
         },
         'angle': 0
     };

--- a/scripts/macros/spells/fogCloud.js
+++ b/scripts/macros/spells/fogCloud.js
@@ -44,8 +44,8 @@ async function item({speaker, actor, token, character, item, args, scope, workfl
                 },
             },
             'walledtemplates': {
-                'wallRestriction': "move",
-                'wallsBlock': "recurse",
+                'wallRestriction': 'move',
+                'wallsBlock': 'recurse',
             },
         },
         'angle': 0


### PR DESCRIPTION
Fog Cloud and Summon Fey (tricksy) will now appropriately block vision with the Vision5e and Limits modules enabled. They will also spread around corners with the walled templates module enabled.