### PR TITLE
Fix Blade Flourish macro

### DIFF
--- a/scripts/macros/classFeatures/bard/collegeOfSwords/bladeFlourish.js
+++ b/scripts/macros/classFeatures/bard/collegeOfSwords/bladeFlourish.js
@@ -58,6 +58,12 @@ export async function bladeFlourish({speaker, actor, token, character, item, arg
         await chris.createEffect(sourceActor, effectData1);
         if (!skipUses) bardicInspiration.update({'system.uses.value': bardicInspirationUses - 1});
         let bardicInspirationDie = sourceActor.system.scale.bard['bardic-inspiration'];
+        if(!bardicInspirationDie){
+            let inspiratonScale = sourceActor.system.scale.bard.inspiration;
+            if(inspiratonScale){
+                bardicInspirationDie = {'formula': `${inspiratonScale.number || 1}d${inspiratonScale.faces}`}
+            }
+        }
         if (skipUses) bardicInspirationDie = {'formula': '1d6'};
         if (!bardicInspirationDie) {
             ui.notifications.warn('Source actor does not appear to have a Bardic Inspiration scale!');


### PR DESCRIPTION
Howdy, noticed this macro did not work anymore. Not sure if that's due to FoundryVTT updates or what exactly.
Added a second attempt to retrieve the bardic inspiration scale based on where it's currently located in Foundry (which is `actor.system.scale.bard.inspiration`).

The new doesn't have a 'formula' field, did the old one? The code seems to imply that. So I just build a formula from the number and faces in the new style object. You'll note in the picture below, number appears to just be `null` in this case so I'm just including the `|| 1` to handle that.

![image](https://github.com/chrisk123999/chris-premades/assets/15028025/eb6c852b-697d-4811-a120-9f2bb81b94c9)
