### PR TITLE
Sequencer Xray option for limits supporting items

### DIFF
--- a/scripts/macros/monsterFeatures/feySpirit/tricksy.js
+++ b/scripts/macros/monsterFeatures/feySpirit/tricksy.js
@@ -37,6 +37,8 @@ export async function tricksy({speaker, actor, token, character, item, args, sco
         }
     });
 
+    let xray = game.settings.get('chris-premades', 'Show Limits Animations');
+    new Sequence().effect().file('jb2a.darkness.black').scaleToObject(1.25).aboveLighting().opacity(0.5).xray(xray).persist(true).attachTo(template).play();
     let effect = chris.findEffect(workflow.actor, workflow.item.name + ' Template');
     if (!effect) return;
     if (!chris.inCombat()) return;

--- a/scripts/macros/spells/darkness.js
+++ b/scripts/macros/spells/darkness.js
@@ -38,15 +38,22 @@ async function darknessItem({speaker, actor, token, character, item, args, scope
         }
     });
     let attachToken = await chris.dialog('Attach to self?', [['Yes', true], ['No', false]]) || false;
-    if (!attachToken) return;
-    let tokenObject = workflow.token;
-    await template.update(
-        {
-            'x': tokenObject.center.x,
-            'y': tokenObject.center.y
-        }
-    );
-    await tokenAttacher.attachElementsToToken([template], tokenObject, false);
+    if (attachToken) {
+        let tokenObject = workflow.token;
+        await template.update(
+            {
+                'x': tokenObject.center.x,
+                'y': tokenObject.center.y
+            }
+        );
+        await tokenAttacher.attachElementsToToken([template], tokenObject, false);
+    };
+    let xray = game.settings.get('chris-premades', 'Show Limits Animations');
+    if(game.modules.get('walledtemplates')) {
+        new Sequence().effect().file('jb2a.darkness.black').scaleToObject().aboveLighting().opacity(0.5).xray(xray).mask(finalTemplate).persist(true).attachTo(template).play();
+    } else {
+        new Sequence().effect().file('jb2a.darkness.black').scaleToObject().aboveLighting().opacity(0.5).xray(xray).persist(true).attachTo(template).play();
+    }
 }
 async function darknessHook(workflow) {
     if (workflow.targets.size != 1) return;

--- a/scripts/macros/spells/fogCloud.js
+++ b/scripts/macros/spells/fogCloud.js
@@ -53,7 +53,8 @@ async function item({speaker, actor, token, character, item, args, scope, workfl
     let templateDoc = new CONFIG.MeasuredTemplate.documentClass(templateData, {'parent': canvas.scene});
     let template = new game.dnd5e.canvas.AbilityTemplate(templateDoc);
     let[finalTemplate] = await template.drawPreview();
-    new Sequence().effect().file('jb2a.fog_cloud.1.white').scale(workflow.castData.castLevel).aboveLighting().opacity(0.5).persist(true).attachTo(finalTemplate).play();
+    let xray = game.settings.get('chris-premades', 'See Limits Animations');
+    new Sequence().effect().file('jb2a.fog_cloud.1.white').scale(workflow.castData.castLevel).aboveLighting().opacity(0.5).xray(xray).persist(true).attachTo(finalTemplate).play();
     let effectData = {
         'label': workflow.item.name,
         'icon': workflow.item.img,

--- a/scripts/macros/spells/fogCloud.js
+++ b/scripts/macros/spells/fogCloud.js
@@ -53,8 +53,12 @@ async function item({speaker, actor, token, character, item, args, scope, workfl
     let templateDoc = new CONFIG.MeasuredTemplate.documentClass(templateData, {'parent': canvas.scene});
     let template = new game.dnd5e.canvas.AbilityTemplate(templateDoc);
     let[finalTemplate] = await template.drawPreview();
-    let xray = game.settings.get('chris-premades', 'See Limits Animations');
-    new Sequence().effect().file('jb2a.fog_cloud.1.white').scale(workflow.castData.castLevel).aboveLighting().opacity(0.5).xray(xray).persist(true).attachTo(finalTemplate).play();
+    let xray = game.settings.get('chris-premades', 'Show Limits Animations');
+    if(game.modules.get('walledtemplates')) {
+        new Sequence().effect().file('jb2a.fog_cloud.1.white').scaleToObject().aboveLighting().opacity(0.5).mask(finalTemplate).xray(xray).persist(true).attachTo(finalTemplate).play();
+    } else {
+        new Sequence().effect().file('jb2a.fog_cloud.1.white').scaleToObject().aboveLighting().opacity(0.5).xray(xray).persist(true).attachTo(finalTemplate).play();
+    }
     let effectData = {
         'label': workflow.item.name,
         'icon': workflow.item.img,

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -264,15 +264,15 @@ export function registerSettings() {
         }
     });
     addMenuSetting('VAE Temporary Item Buttons', 'Module Integration');
-    game.settings.register(moduleName, 'See Limits Animations', {
-        'name': 'See Limits Animations',
+    game.settings.register(moduleName, 'Show Limits Animations', {
+        'name': 'Show Limits Animations',
         'hint': 'When enabled, this setting allows Sequencer effects to be displayed over vision blocking templates.',
         'scope': 'world',
         'config': false,
         'type': Boolean,
         'default': false,
     });
-    addMenuSetting('See Limits Animations', 'Module Integration');
+    addMenuSetting('Show Limits Animations', 'Module Integration');
     game.settings.register(moduleName, 'Condition Fixes', {
         'name': 'Blinded and Invisibility Changes',
         'hint': 'This setting restores the blinded and invisibility conditions to how they worked in version 9 of Foundry.',

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -264,6 +264,15 @@ export function registerSettings() {
         }
     });
     addMenuSetting('VAE Temporary Item Buttons', 'Module Integration');
+    game.settings.register(moduleName, 'See Limits Animations', {
+        'name': 'See Limits Animations',
+        'hint': 'When enabled, this setting allows Sequencer effects to be displayed over vision blocking templates.',
+        'scope': 'world',
+        'config': false,
+        'type': Boolean,
+        'default': false,
+    });
+    addMenuSetting('See Limits Animations', 'Module Integration');
     game.settings.register(moduleName, 'Condition Fixes', {
         'name': 'Blinded and Invisibility Changes',
         'hint': 'This setting restores the blinded and invisibility conditions to how they worked in version 9 of Foundry.',


### PR DESCRIPTION
Add setting in "Module Integration" for sequencer xray on limits supporting items(darkness, fog cloud, tricksy).

- Moved Darkness and Tricksy to Macro animation, the compendium items will need to be edited to turn off AA
- Added sequencer mask if walled templates is installed to stop animations from going through walls (only for the above 3 items)