### PR TITLE
Rideable Grapple Integration Fix

### DIFF
--- a/scripts/macros/actions/grapple.js
+++ b/scripts/macros/actions/grapple.js
@@ -15,7 +15,7 @@ export async function grapple({speaker, actor, token, character, item, args, sco
         if (targetRoll.total >= sourceRoll.total) return;
     }
     if(game.modules.get('Rideable')?.active) {
-        game.Rideable.Mount([targetToken.document], workflow.token.document, {'Grappled': true})
+        game.Rideable.Mount([targetToken.document], workflow.token.document, {'Grappled': true, 'MountingEffectsOverride': ['Grappled']});
     } else {
         await chris.addCondition(targetActor, 'Grappled', false, workflow.item.uuid);
     }

--- a/scripts/macros/monsterFeatures/rugOfSmothering/smother.js
+++ b/scripts/macros/monsterFeatures/rugOfSmothering/smother.js
@@ -2,9 +2,6 @@ import {constants} from '../../../constants.js';
 import {chris} from '../../../helperFunctions.js';
 import {translate} from '../../../translations.js';
 export async function smotherDamage(origin, token, actor) {
-    let sourceTokenId = actor.flags['chris-premades']?.monster?.rugOfSmothering?.smother
-    if (!sourceTokenId) return;
-    if (game.combat.current.tokenId != sourceTokenId) return;
     let featureData = await chris.getItemFromCompendium('chris-premades.CPR Monster Feature Items', 'Rug of Smothering - Smother', false);
     if (!featureData) return;
     featureData.system.description.value = chris.getItemDescription('CPR - Descriptions', 'Rug of Smothering - Smother');
@@ -35,6 +32,6 @@ export async function smother({speaker, actor, token, character, item, args, sco
             'description': workflow.item.name
         };
         await warpgate.mutate(workflow.token.document, targetUpdate, {}, options);
-        game.Rideable.Mount([targetToken.document], workflow.token.document, {'Grappled': true});
+        game.Rideable.Mount([targetToken.document], workflow.token.document, {'Grappled': true, 'MountingEffectsOverride': []});
     }
 }

--- a/scripts/macros/monsterFeatures/shamblingMound/engulf.js
+++ b/scripts/macros/monsterFeatures/shamblingMound/engulf.js
@@ -19,3 +19,21 @@ export async function engulf(origin, token, actor) {
     let [config, options] = constants.syntheticItemWorkflowOptions([token.document.uuid]);
     await MidiQOL.completeItemUse(feature, config, options);
 }
+
+export async function engulfGrapple({speaker, actor, token, character, item, args, scope, workflow}) {
+    if (!workflow.hitTargets.size) return
+    let targetToken = workflow.targets.first();
+    if (game.modules.get('Rideable')?.active) {
+        let targetUpdate = {
+            'token': workflow.token.document.center
+        };
+        let options = {
+            'permanent': true,
+            'name': workflow.item.name,
+            'description': workflow.item.name
+        };
+        console.log(targetToken);
+        await warpgate.mutate(targetToken.document, targetUpdate, {}, options);
+        game.Rideable.Mount([targetToken.document], workflow.token.document, {'Grappled': true, 'MountingEffectsOverride': []});
+    }
+}

--- a/scripts/macros/monsterFeatures/shamblingMound/shamblingMound.js
+++ b/scripts/macros/monsterFeatures/shamblingMound/shamblingMound.js
@@ -1,6 +1,7 @@
-import {engulf} from './engulf.js';
+import {engulf, engulfGrapple} from './engulf.js';
 import {slam} from './slam.js';
 export let shamblingMound = {
     'engulf': engulf,
-    'slam': slam
+    'slam': slam,
+    'engulfGrapple': engulfGrapple
 }


### PR DESCRIPTION
End Rideable Grapple when effect removed
Fix Smother DOT
Add Rideable grapple to engulf

Updated:
[fvtt-Item-smother-4T7Zb7mS5oNAwDp5.json](https://github.com/chrisk123999/chris-premades/files/13575219/fvtt-Item-smother-4T7Zb7mS5oNAwDp5.json)
[fvtt-Item-engulf-M3A3YvJfsvke3ahv.json](https://github.com/chrisk123999/chris-premades/files/13575220/fvtt-Item-engulf-M3A3YvJfsvke3ahv.json)

Needs to be added to Monster Feature Items:
[fvtt-Item-rug-of-smothering-smother-NGMopKxCJ72zFUFg.json](https://github.com/chrisk123999/chris-premades/files/13575216/fvtt-Item-rug-of-smothering-smother-NGMopKxCJ72zFUFg.json)

Smother is also missing an editable journal entry
