### PR TITLE
Fix for Lightning Lure not dealing damage when Animated Spell Effects is enabled

### DIFF
--- a/scripts/macros/spells/lightningLure.js
+++ b/scripts/macros/spells/lightningLure.js
@@ -25,7 +25,7 @@ export async function lightningLure({speaker, actor, token, character, item, arg
         return;
     } else {
         let position = chris.getGridBetweenTokens(sourceToken, target, pullDistance);
-        new Sequence()
+        await new Sequence()
             .effect()
             .atLocation(sourceToken)
             .file('animated-spell-effects-cartoon.electricity.discharge.03')


### PR DESCRIPTION
await the Sequence so the token finishes moving before calculating distance