### PR TITLE
Adjust operator precedence around `getConfiguration` null coalesces

### DIFF
--- a/scripts/macros/mechanics/firearm.js
+++ b/scripts/macros/mechanics/firearm.js
@@ -94,7 +94,7 @@ async function repair({speaker, actor, token, character, item, args, scope, work
         return;
     }
     let roll = await workflow.actor.rollToolCheck('tinker');
-    let misfireDC = 8 + chris.getConfiguration(weapon, 'misfire') ?? 1;
+    let misfireDC = 8 + (chris.getConfiguration(weapon, 'misfire') ?? 1);
     let updates;
     if (roll.total >= misfireDC) {
         updates = {

--- a/scripts/macros/spells/animateDead.js
+++ b/scripts/macros/spells/animateDead.js
@@ -23,7 +23,7 @@ export async function animateDead({speaker, actor, token, character, item, args,
             'disposition': 1 
         }
     }
-    let animation = chris.getConfiguration(workflow.item, 'animation') ?? (chris.jb2aCheck() === 'patreon' && chris.aseCheck()) ? 'shadow' : 'none';
+    let animation = chris.getConfiguration(workflow.item, 'animation') ?? ((chris.jb2aCheck() === 'patreon' && chris.aseCheck()) ? 'shadow' : 'none');
     await summons.spawn(sourceActors, updates, 86400, workflow.item, undefined, undefined, 10, workflow.token, animation);
     let featureData = await chris.getItemFromCompendium('chris-premades.CPR Spell Features', 'Animate Dead - Command', false);
     if (!featureData) return;

--- a/scripts/macros/spells/spiritGuardians.js
+++ b/scripts/macros/spells/spiritGuardians.js
@@ -61,7 +61,7 @@ async function item({speaker, actor, token, character, item, args, scope, workfl
     if (!effect) return;
     await tokenMove.add('spiritGuardians', castLevel, spellDC, damage, damageType, sourceTokenID, range, true, true, 'start', effect.uuid);
     let color = chris.getConfiguration(workflow.item, 'color') ?? 'blueyellow';
-    let variation = '.' + chris.getConfiguration(workflow.item, 'variation') ?? '.ring';
+    let variation = '.' + (chris.getConfiguration(workflow.item, 'variation') ?? 'ring');
     if (color === 'random') {
         let colors = [
             'blueyellow',


### PR DESCRIPTION
Ensure the correct order of operations occurs, preventing cases where invalid values could make their way into a handful of scripts.

This fix was specifically targeted at uses of `getConfiguration`; similar bugs may still be present elsewhere.