### PR TITLE
Update dualWielder.js

### DIFF
--- a/scripts/macros/feats/dualWielder.js
+++ b/scripts/macros/feats/dualWielder.js
@@ -6,7 +6,7 @@ export async function dualWielder(item, updates, options, userId) {
     let effect = chris.findEffect(actor, 'Dual Wielder');
     if (!effect) return;
     let items = actor.items.filter(i => i.type==='weapon' && i.system.equipped);
-    let shields = actor.items.filter(i => i.system.type.value === 'shield' && i.system.equipped);
+    let shields = actor.items.filter(i => i.system.type?.value === 'shield' && i.system.equipped);
     if (shields.length) {
         if (!effect.disabled) await effect.update({'disabled': true});
         return;


### PR DESCRIPTION
In D&D 3.0.x, not every item type has `system.type`, so guard against that being null.