### PR TITLE
Correctly await promise array in `damageRolls` helper

### DIFF
--- a/scripts/helperFunctions.js
+++ b/scripts/helperFunctions.js
@@ -1193,7 +1193,7 @@ export let chris = {
         return await new CONFIG.Dice.DamageRoll(damageFormula, workflow.actor.getRollData(), options).evaluate();
     },
     'damageRolls': async function _damageRolls(workflow, damageFormulas = []) {
-        return damageFormulas.map(i => chris.damageRoll(workflow, i));
+        return Promise.all(damageFormulas.map(i => chris.damageRoll(workflow, i)));
     },
     'hasEpicRolls': function _hasEpicRolls() {
         return game.modules.get('epic-rolls-5e')?.active;


### PR DESCRIPTION
The `damageRolls` helper currently returns an array or promises, which do not get awaited by the caller (in `ancestralProtectors.js`'s `targetDamage`). Wrap this array in a `Promise.all` such that the caller can easily await the whole result.