### PR TITLE
removed manual removal of concentration for thunderous & staggering smite

### DIFF
--- a/scripts/macros/spells/staggeringSmite.js
+++ b/scripts/macros/spells/staggeringSmite.js
@@ -24,8 +24,6 @@ async function damage({speaker, actor, token, character, item, args, scope, work
     await warpgate.wait(100);
     await MidiQOL.completeItemUse(feature, config, options);
     await chris.removeEffect(effect);
-    let conEffect = chris.findEffect(workflow.actor, 'Concentrating');
-    if (conEffect) await chris.removeEffect(conEffect);
     queue.remove(workflow.item.uuid);
 }
 async function item({speaker, actor, token, character, item, args, scope, workflow}) {

--- a/scripts/macros/spells/thunderousSmite.js
+++ b/scripts/macros/spells/thunderousSmite.js
@@ -28,8 +28,6 @@ async function damage({speaker, actor, token, character, item, args, scope, work
         if (!chris.checkTrait(targetToken.actor, 'ci', 'prone')) await chris.addCondition(targetToken.actor, 'Prone');
     }
     await chris.removeEffect(effect);
-    let conEffect = chris.findEffect(workflow.actor, 'Concentrating');
-    if (conEffect) await chris.removeEffect(conEffect);
     queue.remove(workflow.item.uuid);
 }
 async function item({speaker, actor, token, character, item, args, scope, workflow}) {


### PR DESCRIPTION
Midi takes care of it, and currently will result in an error popup when it tries to delete the already-deleted concentration marker.