### PR TITLE
Option to keep original name after update/replace item.

### DIFF
--- a/scripts/item.js
+++ b/scripts/item.js
@@ -234,7 +234,10 @@ export async function updateItem(itemDocument) {
         'content': '<hr><b>' + compendiumItem.name + ':</b><br><hr>' + compendiumItem.system.description.value
     });
     let originalItem = duplicate(itemDocument.toObject());
-    originalItem.name = compendiumItem.name;
+
+    if (!game.settings.get('chris-premades', 'Keep Original Name')) {
+        originalItem.name = compendiumItem.name;
+    }
     originalItem.effects = compendiumItem.effects;
     originalItem.system = compendiumItem.system;
     originalItem.system.description = itemDocument.system.description;

--- a/scripts/item.js
+++ b/scripts/item.js
@@ -235,9 +235,6 @@ export async function updateItem(itemDocument) {
     });
     let originalItem = duplicate(itemDocument.toObject());
 
-    if (!game.settings.get('chris-premades', 'Keep Original Name')) {
-        originalItem.name = compendiumItem.name;
-    }
     originalItem.effects = compendiumItem.effects;
     originalItem.system = compendiumItem.system;
     originalItem.system.description = itemDocument.system.description;

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -1981,13 +1981,4 @@ export function registerSettings() {
         'type': chrisSettingsTroubleshoot,
         'restricted': true
     });
-    game.settings.register(moduleName, 'Keep Original Name', {
-        'name': 'Keep Original Name',
-        'hint': 'With setting item name will stay same after update / replace.',
-        'scope': 'world',
-        'config': false,
-        'type': Boolean,
-        'default': false,
-    });
-    addMenuSetting('Keep Original Name', 'General');
 }

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -1081,7 +1081,7 @@ export function registerSettings() {
                 Hooks.on('midi-qol.preTargetDamageApplication', macros.soothePain);
             } else {
                 Hooks.off('midi-qol.preTargetDamageApplication', macros.soothePain);
-            } 
+            }
         }
     });
     addMenuSetting('Righteous Heritor', 'Feats');
@@ -1981,4 +1981,13 @@ export function registerSettings() {
         'type': chrisSettingsTroubleshoot,
         'restricted': true
     });
+    game.settings.register(moduleName, 'Keep Original Name', {
+        'name': 'Keep Original Name',
+        'hint': 'With setting item name will stay same after update / replace.',
+        'scope': 'world',
+        'config': false,
+        'type': Boolean,
+        'default': false,
+    });
+    addMenuSetting('Keep Original Name', 'General');
 }


### PR DESCRIPTION
Sometimes I update an item with a translated name and I want to keep it instead of changing it to the CPR Compendium name. I added a setting in the 'General' section to retain the name.