### PR TITLE
Blessing of the Forge makes item magical

### DIFF
--- a/scripts/macros/classFeatures/cleric/forgeDomain/blessingOfTheForge.js
+++ b/scripts/macros/classFeatures/cleric/forgeDomain/blessingOfTheForge.js
@@ -21,6 +21,7 @@ export async function blessingOfTheForge({speaker, actor, token, character, item
     } else {
         itemData.system.armor.value += 1;
     }
+    itemData.system.properties.push('mgc');
     let effectData = {
         'label': workflow.item.name,
         'icon': workflow.item.img,


### PR DESCRIPTION
Until the end of your next long rest or until you die, the **object becomes a magic item**, granting a +1 bonus to AC if it's armor or a +1 bonus to attack and damage rolls if it's a weapon