### PR TITLE
Make sure that MidiQOL is not using Bleeding before removing it from status effects (Disable Non-Condition Status Effects).

### DIFF
--- a/scripts/extensions/conditions.js
+++ b/scripts/extensions/conditions.js
@@ -44,7 +44,6 @@ async function configureStatusEffectIcons() {
     await genericUtils.setCPRSetting('statusEffectIcons', selection);
 }
 let ignoredStatusEffects = [
-    'bleeding',
     'burrowing',
     'cursed',
     'ethereal',
@@ -59,6 +58,9 @@ let ignoredStatusEffects = [
     'silenced',
     'dodging'
 ];
+const { addWoundedStyle, midiWoundedCondition } = game.settings.get('midi-qol', 'ConfigSettings');
+if (addWoundedStyle === 'none' || midiWoundedCondition !== 'bleeding')
+    ignoredStatusEffects.push('bleeding');
 function disableNonConditionStatusEffects() {
     CONFIG.statusEffects = CONFIG.statusEffects.filter(i => !ignoredStatusEffects.includes(i.id));
 }


### PR DESCRIPTION
- Take note of the MidiQOL settings before adding `bleeding` in the `ignoredStatusEffects` Array, as otherwise it can introduce an issue with MidiQOL expexting that to be available.

- Cannot be sure without some testing about when each module does its thing, so it might still not be enough.