### PR TITLE
Make sure that MidiQOL is not using Bleeding before removing it from status effects (take 2).

### DIFF
--- a/scripts/extensions/conditions.js
+++ b/scripts/extensions/conditions.js
@@ -44,7 +44,6 @@ async function configureStatusEffectIcons() {
     await genericUtils.setCPRSetting('statusEffectIcons', selection);
 }
 let ignoredStatusEffects = [
-    'bleeding',
     'burrowing',
     'cursed',
     'ethereal',
@@ -59,6 +58,9 @@ let ignoredStatusEffects = [
     'silenced',
     'dodging'
 ];
+const { addWoundedStyle, midiWoundedCondition } = game.settings.get('midi-qol', 'ConfigSettings');
+if (addWoundedStyle === 'none' || midiWoundedCondition !== 'bleeding')
+    ignoredStatusEffects.push('bleeding');
 function disableNonConditionStatusEffects() {
     CONFIG.statusEffects = CONFIG.statusEffects.filter(i => !ignoredStatusEffects.includes(i.id));
 }

--- a/scripts/extensions/conditions.js
+++ b/scripts/extensions/conditions.js
@@ -58,10 +58,10 @@ let ignoredStatusEffects = [
     'silenced',
     'dodging'
 ];
-const { addWoundedStyle, midiWoundedCondition } = game.settings.get('midi-qol', 'ConfigSettings');
-if (addWoundedStyle === 'none' || midiWoundedCondition !== 'bleeding')
-    ignoredStatusEffects.push('bleeding');
 function disableNonConditionStatusEffects() {
+    const { addWoundedStyle, midiWoundedCondition } = game.settings.get('midi-qol', 'ConfigSettings');
+    if (addWoundedStyle === 'none' || midiWoundedCondition !== 'bleeding')
+        ignoredStatusEffects.push('bleeding');
     CONFIG.statusEffects = CONFIG.statusEffects.filter(i => !ignoredStatusEffects.includes(i.id));
 }
 async function preCreateActiveEffect(effect, updates, options, userId) {

--- a/scripts/module.js
+++ b/scripts/module.js
@@ -38,7 +38,6 @@ Hooks.once('init', () => {
     if (utils.genericUtils.getCPRSetting('useLocalCompendiums')) utils.constants.setUseLocalCompendium(true);
     registerMenus();
     customTypes.init();
-    if (utils.genericUtils.getCPRSetting('disableNonConditionStatusEffects')) conditions.disableNonConditionStatusEffects();
     if (utils.genericUtils.getCPRSetting('replaceStatusEffectIcons')) conditions.setStatusEffectIcons();
     if (utils.genericUtils.getCPRSetting('effectInterface')) effectInterface.init();
     if (utils.genericUtils.getCPRSetting('macroInterface')) macroInterface.init();
@@ -57,6 +56,7 @@ Hooks.once('ready', () => {
     if (game.modules.get('gambits-premades')?.active) gambitPremades.init(utils.genericUtils.getCPRSetting('gambitPremades'));
     if (game.modules.get('midi-item-showcase-community')?.active) miscPremades.init(utils.genericUtils.getCPRSetting('miscPremades'));
     if (utils.genericUtils.getCPRSetting('disableSpecialEffects')) conditions.disableSpecialEffects(true);
+    if (utils.genericUtils.getCPRSetting('disableNonConditionStatusEffects')) conditions.disableNonConditionStatusEffects();
     if (utils.genericUtils.getCPRSetting('firearmSupport')) customTypes.firearm(true);
     if (game.user.isGM) {
         game.settings.set('chris-premades', 'gmID', game.user.id);


### PR DESCRIPTION
- Moved the `if (utils.genericUtils.getCPRSetting('disableNonConditionStatusEffects')) conditions.disableNonConditionStatusEffects();` to the ready hook.

- Moved the filtering of `bleeding` inside the `disableNonConditionStatusEffects()`