### PR TITLE
Light level of a coordinate (x,y,z)

### DIFF
--- a/scripts/lib/utilities/sceneUtils.js
+++ b/scripts/lib/utilities/sceneUtils.js
@@ -1,0 +1,19 @@
+/* TODO: This uses cartesian... not ideal since most people use 5/5/5 or 5/10/5 rather than cartesian... */
+function fromLightCenter(light, coord) {
+    let distance = Math.hypot((light.data.x - coord.x), (light.data.y - coord.y));
+    if (coord.z) distance = Math.hypot(distance, (light.data.elevation - coord.z));
+    return distance;
+}
+
+function getLightLevel(coord = {x, y, z}) {
+    let lights = canvas.effects.lightSources.filter(src => !(src instanceof foundry.canvas.sources.GlobalLightSource));
+    let bright = lights.filter(src => fromLightCenter(src, coord) <= src.data.bright);
+    if (bright.length) return 'bright';
+    let dim = lights.filter(src => fromLightCenter(src, coord) <= src.data.dim);
+    if (dim.length) return 'dim';
+    return 'dark';
+}
+
+export let sceneUtils = {
+    getLightLevel
+};

--- a/scripts/lib/utilities/tokenUtils.js
+++ b/scripts/lib/utilities/tokenUtils.js
@@ -1,4 +1,4 @@
-import {actorUtils, dialogUtils, effectUtils, genericUtils, itemUtils, socketUtils, workflowUtils} from '../../utils.js';
+import {actorUtils, dialogUtils, effectUtils, genericUtils, itemUtils, sceneUtils, socketUtils, workflowUtils} from '../../utils.js';
 function getDistance(sourceToken, targetToken, {wallsBlock, checkCover} = {}) {
     // return MidiQOL.computeDistance(sourceToken, targetToken, wallsBlock, checkCover);
     if (checkCover) {
@@ -438,19 +438,7 @@ async function attachToToken(token, uuidsToAttach) {
 }
 function getLightLevel(token) {
     if (token.document.parent.environment.globalLight.enabled) return 'bright';
-    let c = Object.values(token.center);
-    let lights = canvas.effects.lightSources.filter(src => !(src instanceof foundry.canvas.sources.GlobalLightSource) && src.shape.contains(...c));
-    if (!lights.length) return 'dark';
-    let inBright = lights.some(light => {
-        let {data: {x, y}, ratio} = light;
-        let bright = ClockwiseSweepPolygon.create({'x': x, 'y': y}, {
-            type: 'light',
-            boundaryShapes: [new PIXI.Circle(x, y, ratio * light.shape.config.radius)]
-        });
-        return bright.contains(...c);
-    });
-    if (inBright) return 'bright';
-    return 'dim';
+    return sceneUtil.getLightLevel({x: token.center.x, y: token.center.y, z: token.elevationZ})
 }
 export let tokenUtils = {
     getDistance,

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -6,6 +6,7 @@ export {effectUtils} from './lib/utilities/effectUtils.js';
 export {genericUtils} from './lib/utilities/genericUtils.js';
 export {itemUtils} from './lib/utilities/itemUtils.js';
 export {rollUtils} from './lib/utilities/rollUtils.js';
+export {sceneUtils} from './lib/utilities/sceneUtils.js';
 export {socketUtils} from './lib/utilities/socketUtils.js';
 export {templateUtils} from './lib/utilities/templateUtils.js';
 export {workflowUtils} from './lib/utilities/workflowUtils.js';


### PR DESCRIPTION
Token light level disregards elevation currently. A quick (and admittedly dirty) fix using Cartesian math, adding ability to poll arbitrary points as well for things like Shadow Step which require knowledge of the brightness of a location, not a token.

Open to suggestions on how to fix computation distance! Even if you aren't pulling this in, I'd like to figure out how to fix it locally for myself afterall.