### PR TITLE
Remove Bleeding from Ignored status effects

### DIFF
--- a/scripts/extensions/conditions.js
+++ b/scripts/extensions/conditions.js
@@ -44,7 +44,6 @@ async function configureStatusEffectIcons() {
     await genericUtils.setCPRSetting('statusEffectIcons', selection);
 }
 let ignoredStatusEffects = [
-    'bleeding',
     'burrowing',
     'cursed',
     'ethereal',


### PR DESCRIPTION
Remove `bleeding` from ignored status effects to improve compatibilty with MidiQOL's mechanics and `midiWoundedCondition` set to the system's Bleeding.

Turning on and off CPR shouldn't create an incompatibility with already set Midi conditions.

*Same for dnd4 branch, but just saw I hadn't pulled that branch in*