### PR TITLE
Update masteries.js

### DIFF
--- a/scripts/macros/2024/mechanics/masteries.js
+++ b/scripts/macros/2024/mechanics/masteries.js
@@ -164,7 +164,7 @@ async function RollComplete(workflow) {
     let baseItem = workflow.item.system.type.baseItem;
     if (baseItem === '') return;
     if (!workflow.actor.system.traits?.weaponProf?.mastery?.value?.has(baseItem)) return;
-    let mastery = workflow.item.system.mastery;
+    let mastery = workflow.attackRoll.options.mastery;
     if (!mastery) return;
     let macro = custom.getMacro(mastery + 'Mastery', 'modern');
     if (!macro) return;


### PR DESCRIPTION
Update the post-roll function to get the mastery property from the attack roll to account for the attacker using the dropdown in the attack roll dialog to use a different mastery property (relevant to fighters with the Tactical Master feature).