### PR TITLE
Fix type handling in addToRoll function for formula parameter

### DIFF
--- a/scripts/lib/utilities/rollUtils.js
+++ b/scripts/lib/utilities/rollUtils.js
@@ -95,8 +95,7 @@ async function damageRoll(formula, actor, options = {}) {
     return await new CONFIG.Dice.DamageRoll(formula, actor.getRollData(), options).evaluate();
 }
 async function addToRoll(roll, formula, {rollData} = {}) {
-    let formulaString = typeof formula === 'string' ? formula : String(formula);
-    let bonusRoll = await new Roll(formulaString, rollData).evaluate();
+    let bonusRoll = await new Roll(String(formula), rollData).evaluate();
     return MidiQOL.addRollTo(roll, bonusRoll);
 }
 async function remoteRoll(roll, userId) {

--- a/scripts/lib/utilities/rollUtils.js
+++ b/scripts/lib/utilities/rollUtils.js
@@ -95,7 +95,8 @@ async function damageRoll(formula, actor, options = {}) {
     return await new CONFIG.Dice.DamageRoll(formula, actor.getRollData(), options).evaluate();
 }
 async function addToRoll(roll, formula, {rollData} = {}) {
-    let bonusRoll = await new Roll(formula, rollData).evaluate();
+    let formulaString = typeof formula === 'string' ? formula : String(formula);
+    let bonusRoll = await new Roll(formulaString, rollData).evaluate();
     return MidiQOL.addRollTo(roll, bonusRoll);
 }
 async function remoteRoll(roll, userId) {


### PR DESCRIPTION
Ensure the 'formula' parameter in addToRoll is properly converted to a string when not already of type string. This prevents potential errors when evaluating the roll (For example, Psychic Blade -> Homing Strikes roll a number instead of string formula)