### PR TITLE
Add Babele translation support to premade-module initialization

### DIFF
--- a/scripts/hooks.js
+++ b/scripts/hooks.js
@@ -7,7 +7,14 @@ import {midiEvents} from './events/midi.js';
 import {movementEvents} from './events/movement.js';
 import {templateEvents} from './events/template.js';
 import {dae} from './integrations/dae.js';
-import {createHeaderButton, renderItemSheet, renderEffectConfig, renderCompendium, renderActivitySheet, renderRegionConfig} from './extensions/titlebar.js';
+import {
+    createHeaderButton,
+    renderItemSheet,
+    renderEffectConfig,
+    renderCompendium,
+    renderActivitySheet,
+    renderRegionConfig
+} from './extensions/titlebar.js';
 import {genericUtils, itemUtils} from './utils.js';
 import {chat} from './extensions/chat.js';
 import {sidebar} from './extensions/sidebar.js';
@@ -26,6 +33,10 @@ import {activities} from './extensions/activities.js';
 import {itemEvent} from './events/item.js';
 import {template} from './extensions/template.js';
 import {tidy5e} from './integrations/tidy5e.js';
+import {gambitPremades} from './integrations/gambitsPremades';
+import * as utils from './utils';
+import {miscPremades} from './integrations/miscPremades';
+
 export function registerHooks() {
     Hooks.on('createSetting', genericUtils.createUpdateSetting);
     Hooks.on('updateSetting', genericUtils.createUpdateSetting);
@@ -118,4 +129,11 @@ export function registerHooks() {
     }
     Hooks.once('tidy5e-sheet.ready', tidy5e.itemTitleBar);
     Hooks.on('aa.preDataSanitize', automatedAnimations.preDataSanitize);
+    if (game.modules.get('babele')?.active) {
+        Hooks.once('babele.ready', () => {
+            if (game.modules.get('gambits-premades')?.active) gambitPremades.init(utils.genericUtils.getCPRSetting('gambitPremades'));
+            if (game.modules.get('midi-item-showcase-community')?.active) miscPremades.init(utils.genericUtils.getCPRSetting('miscPremades'));
+        });
+    }
+
 }

--- a/scripts/module.js
+++ b/scripts/module.js
@@ -64,8 +64,10 @@ Hooks.once('ready', () => {
     registerHooks();
     ddbi.ready();
     dae.injectFlags();
-    if (game.modules.get('gambits-premades')?.active) gambitPremades.init(utils.genericUtils.getCPRSetting('gambitPremades'));
-    if (game.modules.get('midi-item-showcase-community')?.active) miscPremades.init(utils.genericUtils.getCPRSetting('miscPremades'));
+    if (!game.modules.get('babele')?.active) {
+        if (game.modules.get('gambits-premades')?.active) gambitPremades.init(utils.genericUtils.getCPRSetting('gambitPremades'));
+        if (game.modules.get('midi-item-showcase-community')?.active) miscPremades.init(utils.genericUtils.getCPRSetting('miscPremades'));
+    }
     if (utils.genericUtils.getCPRSetting('disableSpecialEffects')) conditions.disableSpecialEffects(true);
     if (utils.genericUtils.getCPRSetting('firearmSupport')) customTypes.firearm(true);
     if (game.user.isGM) {


### PR DESCRIPTION
I’m working on compendiums translations using the Babele module. The default CPR packs are fine, but the Gambits/Misc packs initializes before Babele translates it, so the Medkit doesn’t work properly (unless you manually re-init Gambits/Misc).  
This change checks whether the Babele module is present and defers initialization of the premade modules until after Babele has loaded.
