### PR TITLE
Adds a `cprInitComplete` hook

### DIFF
--- a/scripts/module.js
+++ b/scripts/module.js
@@ -55,6 +55,7 @@ Hooks.once('init', () => {
         Hooks.on('getItemDirectory5eEntryContext', itemDirectory.itemContext);
         Hooks.on('getActorDirectoryEntryContext', itemDirectory.actorContext);
     }
+    Hooks.callAll('cprInitComplete');
 });
 Hooks.once('i18nInit', () => {
     dae.initFlags();


### PR DESCRIPTION
Called from within the CPR hook on `init`

Closes #406 