### PR TITLE
Manual Roll Resolver - Setting to allow non-sum behavior

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -292,10 +292,10 @@
         },
         "Distance": {
             "0": "0 ft.",
+            "5": "5 ft.",
             "10": "10 ft.",
             "15": "15 ft.",
             "20": "20 ft.",
-            "5": "5 ft.",
             "DistanceFeet": "{distance} ft."
         },
         "EffectInterface": {
@@ -606,6 +606,7 @@
             "Configure": "Configure",
             "ConsumeItemToUse": "Consume a usage of {item} to use?",
             "ConsumeSpellSlotToUse": "Consume a spell slot to use?",
+            "DiceOnly": "Die Result",
             "Disabled": "Disabled",
             "Distance": "Distance",
             "Edit": "Edit",
@@ -2935,6 +2936,10 @@
                 "Hint": "What actor's rolls should be prompted for.",
                 "Name": "Manual Rolls Inclusion"
             },
+            "manualRollsInputDiceOnly": {
+                "Hint": "Input dice results only, excluding modifiers.",
+                "Name": "Input Dice Only"
+            },
             "manualRollsPromptNoData": {
                 "Hint": "Prompt for rolls with no data, likely used in macros.",
                 "Name": "Prompt on No Data"
@@ -3203,14 +3208,6 @@
                 "Content": "All automations available in this module are stored here.",
                 "Title": "Compendiums"
             },
-            "10": {
-                "Content": "This module has many settings. Please make sure to carefully go through them all and only enable the ones you need.",
-                "Title": "Module Settings"
-            },
-            "11": {
-                "Content": "Further assistance may be found in the help category.",
-                "Title": "Help"
-            },
             "2": {
                 "Content": "As an example, the spell \"Fire Shield\" is stored in the \"CPR Spells\" compendium. You can drag the spell from this compendium onto your actor to use it.",
                 "Title": "Compendiums"
@@ -3242,6 +3239,14 @@
             "9": {
                 "Content": "For example, the spell \"Dragon's Breath\" will make a temporary feature called \"Dragon Breath\" on the target actor.\nFilling in this journal page will populate the description when it's created.",
                 "Title": "Description Journal"
+            },
+            "10": {
+                "Content": "This module has many settings. Please make sure to carefully go through them all and only enable the ones you need.",
+                "Title": "Module Settings"
+            },
+            "11": {
+                "Content": "Further assistance may be found in the help category.",
+                "Title": "Help"
             },
             "Chat": "<hr>View a guided tour of Cauldron of Plentiful Resources here:<br><button class=\"chris-tour\" type=\"button\">Start Tour</button>",
             "Description": "Take a tour of Cauldron of Plentiful Resources.",

--- a/scripts/applications/rollResolverMultiple.js
+++ b/scripts/applications/rollResolverMultiple.js
@@ -82,13 +82,16 @@ export class CPRMultipleRollResolver extends HandlebarsApplicationMixin(Applicat
         return super.close(options);
     }
     async _prepareContext(_options) {
+        const diceOnly = genericUtils.getCPRSetting('manualRollsInputDiceOnly');
+        const placeholderKey = diceOnly ? 'CHRISPREMADES.Generic.DiceOnly' : 'CHRISPREMADES.Generic.Total';
         const context = {
             groups: [],
             options: {
                 name: this.rolls[0]?.data?.name,
                 itemName: this.rolls[0].data?.item?.name,
             },
-            buttons: [{type: 'submit', action: 'confirm', label: 'CHRISPREMADES.Generic.Submit', name: 'confirm', icon: 'fa-solid fa-check'}]
+            buttons: [{type: 'submit', action: 'confirm', label: 'CHRISPREMADES.Generic.Submit', name: 'confirm', icon: 'fa-solid fa-check'}],
+            placeholder: genericUtils.translate(placeholderKey) //placeholder text depending on 'manualRollsInputDiceOnly' setting
         };
         this.rolls.forEach(roll => {
             let damageType = roll.options.type ?? roll.options.flavor ?? 'none';
@@ -194,7 +197,9 @@ export class CPRMultipleRollResolver extends HandlebarsApplicationMixin(Applicat
                         } else if (die instanceof CONFIG.Dice.termTypes.OperatorTerm) {
                             dice.multiplier = die.operator === '-' ? -1 : 1;
                         } else if (die instanceof CONFIG.Dice.termTypes.NumericTerm) {
-                            total -= (die.number * dice.multiplier);
+                            if (!genericUtils.getCPRSetting('manualRollsInputDiceOnly')) {
+                                total -= (die.number * dice.multiplier);
+                            }
                         }
                     });
                     return dice;

--- a/scripts/applications/rollResolverMultiple.js
+++ b/scripts/applications/rollResolverMultiple.js
@@ -76,7 +76,7 @@ export class CPRMultipleRollResolver extends HandlebarsApplicationMixin(Applicat
     }
     async close(options={}) {
         // eslint-disable-next-line no-undef
-        if ( this.rendered ) await this.constructor._fulfillRoll.call(this, null, null, new FormDataExtended(this.element));
+        if ( this.rendered ) await this.constructor._fulfillRoll.call(this, null, null, new foundry.applications.ux.FormDataExtended(this.element));
         this.rolls.forEach(roll => Roll.defaultImplementation.RESOLVERS.delete(roll)); //
         this.#resolve?.();
         return super.close(options);
@@ -190,7 +190,7 @@ export class CPRMultipleRollResolver extends HandlebarsApplicationMixin(Applicat
                         if (die instanceof CONFIG.Dice.termTypes.DiceTerm) {
                             for (let i = 0; i < die.number; i++) {
                                 dice.terms.push(die.faces);
-                            }   
+                            }
                         } else if (die instanceof CONFIG.Dice.termTypes.OperatorTerm) {
                             dice.multiplier = die.operator === '-' ? -1 : 1;
                         } else if (die instanceof CONFIG.Dice.termTypes.NumericTerm) {
@@ -205,7 +205,7 @@ export class CPRMultipleRollResolver extends HandlebarsApplicationMixin(Applicat
                     results = diceResults.map((i, index) => ({faces: dice[index], result: i}));
                 } else results = (dice.reduce((results, number) => {
                     results.diceLeft -= 1; // Remove one from the total left, since we're determining that one now.
-                    if (number + results.diceLeft <= total) { 
+                    if (number + results.diceLeft <= total) {
                         // If the die we're on plus the amount of dice we have left is less than what we have to work with, make the die it's max value
                         // ie total is 10, we have 2 dice left, our current number is a 6, we have at least enough to make this 6 and max and the others at least 1.
                         genericUtils.log('dev', 'Roll Resolver Multiple - max amount for d' + number);

--- a/scripts/applications/rollResolverSingle.js
+++ b/scripts/applications/rollResolverSingle.js
@@ -106,6 +106,8 @@ export class CPRSingleRollResolver extends HandlebarsApplicationMixin(Applicatio
         return super.close(options);
     }
     async _prepareContext(_options) {
+        const diceOnly = genericUtils.getCPRSetting('manualRollsInputDiceOnly');
+        const placeholderKey = diceOnly ? 'CHRISPREMADES.Generic.DiceOnly' : 'CHRISPREMADES.Generic.Total';
         const context = {
             formula: this.roll.formula,
             groups: [{
@@ -113,7 +115,7 @@ export class CPRSingleRollResolver extends HandlebarsApplicationMixin(Applicatio
                 value: this.roll.total,
                 ids: [], //each term's ids
                 icons: [], //each term's icon
-                max: undefined
+                max: undefined,
             }],
             options: {
                 advantageMode: this.roll.options.advantageMode,
@@ -129,7 +131,8 @@ export class CPRSingleRollResolver extends HandlebarsApplicationMixin(Applicatio
                     if (cur instanceof CONFIG.Dice.termTypes.NumericTerm) acc += cur.number;
                 }, 0)
             },
-            buttons: [{type: 'submit', label: 'CHRISPREMADES.Generic.Submit', name: 'confirm', icon: 'fa-solid fa-check'}]
+            buttons: [{type: 'submit', label: 'CHRISPREMADES.Generic.Submit', name: 'confirm', icon: 'fa-solid fa-check'}],
+            placeholder: genericUtils.translate(placeholderKey) //placeholder text depending on 'manualRollsInputDiceOnly' setting
         };
         context.options.content = (!context.options.name || !context.options.type) ? context.formula : context.options.name + ' - ' + context.options.type;
         if (this.roll.options?.rollType?.toLowerCase()?.includes('attack')) context.quickButtons = [
@@ -200,7 +203,9 @@ export class CPRSingleRollResolver extends HandlebarsApplicationMixin(Applicatio
                     } else if (die instanceof CONFIG.Dice.termTypes.OperatorTerm) {
                         dice.multiplier = die.operator === '-' ? -1 : 1;
                     } else if (die instanceof CONFIG.Dice.termTypes.NumericTerm) {
-                        total -= (die.number * dice.multiplier);
+                        if (!genericUtils.getCPRSetting('manualRollsInputDiceOnly')) {
+                            total -= (die.number * dice.multiplier);
+                        }
                     }
                     return dice;
                 }, {terms: [], max: 0, multiplier: 1}));

--- a/scripts/applications/rollResolverSingle.js
+++ b/scripts/applications/rollResolverSingle.js
@@ -115,7 +115,7 @@ export class CPRSingleRollResolver extends HandlebarsApplicationMixin(Applicatio
                 value: this.roll.total,
                 ids: [], //each term's ids
                 icons: [], //each term's icon
-                max: undefined,
+                max: undefined
             }],
             options: {
                 advantageMode: this.roll.options.advantageMode,

--- a/scripts/applications/rollResolverSingle.js
+++ b/scripts/applications/rollResolverSingle.js
@@ -100,7 +100,7 @@ export class CPRSingleRollResolver extends HandlebarsApplicationMixin(Applicatio
     }
     async close(options={}) {
         // eslint-disable-next-line no-undef
-        if ( this.rendered ) await this.constructor._fulfillRoll.call(this, null, null, new FormDataExtended(this.element));
+        if ( this.rendered ) await this.constructor._fulfillRoll.call(this, null, null, new foundry.applications.ux.FormDataExtended(this.element));
         Roll.defaultImplementation.RESOLVERS.delete(this.roll);
         this.#resolve?.();
         return super.close(options);
@@ -196,7 +196,7 @@ export class CPRSingleRollResolver extends HandlebarsApplicationMixin(Applicatio
                         dice.max += (die.faces * dieAmount);
                         for (let i = 0; i < dieAmount; i++) {
                             dice.terms.push(die.faces);
-                        }   
+                        }
                     } else if (die instanceof CONFIG.Dice.termTypes.OperatorTerm) {
                         dice.multiplier = die.operator === '-' ? -1 : 1;
                     } else if (die instanceof CONFIG.Dice.termTypes.NumericTerm) {
@@ -211,7 +211,7 @@ export class CPRSingleRollResolver extends HandlebarsApplicationMixin(Applicatio
                 } else results = (dice.terms.reduce((results, number) => {
                     results.diceLeft -= 1;
                     if (number + results.diceLeft <= total) {
-                        let value = ((number === this.roll?.options?.critical) && (total != dice.max)) ? number - 1 : number; 
+                        let value = ((number === this.roll?.options?.critical) && (total != dice.max)) ? number - 1 : number;
                         results.diceArray.push({faces: number, result: value});
                         total -= value;
                     } else if (1 + results.diceLeft >= total) {

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -287,7 +287,7 @@ export function registerSettings() {
             if (value) {
                 Hooks.on('preCreateActiveEffect', conditions.preCreateActiveEffect);
             } else {
-                Hooks.off('preCreateActiveEffect', conditions.preCreateActiveEffect); 
+                Hooks.off('preCreateActiveEffect', conditions.preCreateActiveEffect);
             }
         }
     });
@@ -631,6 +631,12 @@ export function registerSettings() {
         category: 'manualRolls'
     });
     addSetting({
+    key: 'manualRollsInputDiceOnly',
+    type: Boolean,
+    default: false,
+    category: 'manualRolls'
+    });
+    addSetting({
         key: 'explodingHeals',
         type: Boolean,
         default: false,
@@ -948,14 +954,14 @@ export function registerSettings() {
         type: Boolean,
         default: false,
         category: 'interface',
-        onChange: (value) => ui.customSidebar(value)         
+        onChange: (value) => ui.customSidebar(value)
     });
     addSetting({
         key: 'customChatMessage',
         type: Boolean,
         default: false,
         category: 'interface',
-        onChange: (value) => ui.customChatMessage(value)         
+        onChange: (value) => ui.customChatMessage(value)
     });
     addSetting({
         key: 'disableSettingsWarning',

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -631,10 +631,10 @@ export function registerSettings() {
         category: 'manualRolls'
     });
     addSetting({
-    key: 'manualRollsInputDiceOnly',
-    type: Boolean,
-    default: false,
-    category: 'manualRolls'
+        key: 'manualRollsInputDiceOnly',
+        type: Boolean,
+        default: false,
+        category: 'manualRolls'
     });
     addSetting({
         key: 'explodingHeals',

--- a/styles/module.css
+++ b/styles/module.css
@@ -122,10 +122,11 @@ form .cpr-row-center {
     flex-direction: row;
     flex-wrap: nowrap;
     width: 100%;
-    padding: 1%;
+    padding: 1% 1% 2% 1%;
     align-items: center;
     text-wrap: nowrap;
     gap: 0.625em;
+    justify-content: center;
 }
 
 form .cpr-row-center.cpr-multi-select-row {
@@ -521,11 +522,10 @@ form .cpr-settings.categories .form-group .form-fields > input[type="checkbox"] 
 
 .roll-resolver-quick-buttons .cpr-fieldset.cpr-row-center {
     margin: 0px 0px 10px 0px;
-    gap: 0px;
 }
 
 .roll-resolver-quick-buttons .cpr-fieldset.cpr-row-center button {
-    box-shadow: 0 0 5px 0px var(--button-border-color);
+    box-shadow: 0 0 4px 0px var(--button-border-color);
     border: none;
 }
 

--- a/styles/module.css
+++ b/styles/module.css
@@ -126,7 +126,11 @@ form .cpr-row-center {
     align-items: center;
     text-wrap: nowrap;
     gap: 0.625em;
-    justify-content: center;
+    justify-content: space-between;
+}
+
+form .cpr-row-center button {
+    flex: 1;
 }
 
 form .cpr-row-center.cpr-multi-select-row {

--- a/templates/roll-resolver-multiple-form.hbs
+++ b/templates/roll-resolver-multiple-form.hbs
@@ -8,7 +8,7 @@
                 {{formula}}
             </p>
             <label class="icon die-input">
-                <input type="text" id="{{damageType}}" name="{{damageType}}" max="{{max}}" step="1" autofocus placeholder="{{localize "CHRISPREMADES.Generic.Total"}}">
+                <input type="text" id="{{damageType}}" name="{{damageType}}" max="{{max}}" step="1" autofocus placeholder="{{@root.placeholder}}">
                 <img class="damage-type-icon" src="{{icon}}" alt="{{damageTypeLabel}}">
             </label>
             <p class="roll-resolver-group-content">

--- a/templates/roll-resolver-single-form.hbs
+++ b/templates/roll-resolver-single-form.hbs
@@ -1,5 +1,4 @@
 <div id="cpr-roll-resolver" class="roll-resolver-form standard-form">
-    {{log 'DEBUG' groups}}
     <p class="roll-resolver-content" data-bonus-total="{{options.bonusTotal}}">
         {{options.content}}
     </p>

--- a/templates/roll-resolver-single-form.hbs
+++ b/templates/roll-resolver-single-form.hbs
@@ -1,4 +1,5 @@
 <div id="cpr-roll-resolver" class="roll-resolver-form standard-form">
+    {{log 'DEBUG' groups}}
     <p class="roll-resolver-content" data-bonus-total="{{options.bonusTotal}}">
         {{options.content}}
     </p>
@@ -13,7 +14,7 @@
         <div class="roll-resolver-group roll-resolver-flex" data-ids="{{ids}}">
             {{formula}}
             <label class="icon die-input">
-                <input type="text" id="total" name="total" autofocus placeholder="{{localize "CHRISPREMADES.Generic.Total"}}">
+                <input type="text" id="total" name="total" autofocus placeholder="{{@root.placeholder}}">
                 {{#each icons}}{{{this}}}{{/each}}
             </label>
         </div>


### PR DESCRIPTION
First PR! Trying to help out where I can with minor things. Not sure if your eslint removes whitespace or if I'm using the wrong setting somewhere so feel free to tell me to fix. 

- Fix deprecation warnings with FormDataExtended.
- Add optional setting (default disabled) to have CPR Roll Resolvers expect the die count instead of the sum of the roll, which mimics core manual roll behavior.
- CSS tweaks to improve roll resolver UI