### PR TITLE
Fix CSS in various popups

### DIFF
--- a/styles/module.css
+++ b/styles/module.css
@@ -58,9 +58,10 @@ form .cpr-dialog .form-group button.form-button {
 }
 
 form .cpr-dialog .form-group img.button-image {
-    width: 50px;
-    height: 50px;
-    border: 0px;
+    position: relative;
+    width: 50px !important;
+    height: 50px !important;
+    border: 0px !important;
     margin-left: 5px;
     margin-right: 5px;
     margin-bottom: 5px;


### PR DESCRIPTION
Some popups that ask the user to choose spells, for example, seem to have styling issues where the buttons' images are being forced to 100% width and height by core Foundry css (init.css). This minor tweak ensures that the CPR module's styling still applies, making the popups functional again.