### PR TITLE
Error when a user starts a skill check but closes the dialog without rolling

### DIFF
--- a/scripts/events/skillCheck.js
+++ b/scripts/events/skillCheck.js
@@ -293,7 +293,7 @@ async function rollSkill(wrapped, config, dialog = {}, message = {}) {
         ...options
     };
     let returnData = await wrapped(config, dialog, {...message, create: false});
-    returnData = returnData[0];
+    returnData = returnData?.[0];
     if (!returnData) return;
     let oldOptions = returnData.options;
     returnData = await executeBonusMacroPass(this, 'bonus', skillId, options, returnData, config, dialog, message);


### PR DESCRIPTION
```js
Uncaught (in promise) TypeError: Cannot read properties of null (reading '0')
[Detected 1 package: chris-premades(1.3.122)]
    at Actor5e.yx (skillCheck.js:296:18)
```

It could be on other events too, I haven't checked.