### PR TITLE
`CodeMirror` Height Restrictions

### DIFF
--- a/scripts/applications/embeddedMacros.js
+++ b/scripts/applications/embeddedMacros.js
@@ -931,8 +931,7 @@ export class EmbeddedMacros extends HandlebarsApplicationMixin(ApplicationV2) {
             contentClasses: ['standard-form']
         },
         position: {
-            width: 700,
-            height: 'auto'
+            width: 700
         }
     };
     static PARTS = {
@@ -1147,14 +1146,6 @@ export class EmbeddedMacros extends HandlebarsApplicationMixin(ApplicationV2) {
             tabs: this.tabsData
         };
         return context;
-    }
-    async _reRender() {
-        let autoPos = {...this.position, height: 'auto'};
-        this.setPosition(autoPos);
-        await this.render(true);
-        let maxHeight = canvas.screenDimensions[1] * 0.9;
-        let newPos = {...this.position, height: Math.min(this.element.scrollHeight, maxHeight), top:null};
-        this.setPosition(newPos);
     }
     async _onChangeForm(formConfig, event) {
         let targetInput = event.target;

--- a/styles/module.css
+++ b/styles/module.css
@@ -106,13 +106,46 @@ form .cpr-dialog .form-group .flexcol > div.select-many > multi-select {
     margin: 0.625em 0 0.625em 0;
 }
 
+form#cpr-embedded-macros-window {
+    height: auto;
+    max-height: 90vh;
+    display: flex;
+    flex-direction: column;
+}
+
+form#cpr-embedded-macros-window [data-application-part="header"],
+form#cpr-embedded-macros-window [data-application-part="navigation"] {
+    flex: 0 0 auto;
+}
+
 form#cpr-embedded-macros-window [data-application-part="form"] {
+    flex: 1 1 auto;
+    overflow-y: auto;
+    min-height: 0;
+
     .form-group {
         margin-bottom: 0.5rem;
     }
 
     button {
         width: 100%;
+    }
+
+    /* Lock down CodeMirror height to prevent dynamic resizing */
+    code-mirror {
+        display: block !important;
+        height: 400px !important;
+        max-height: 400px !important;
+        overflow: hidden !important;
+    }
+
+    code-mirror .cm-editor {
+        height: 100% !important;
+    }
+
+    code-mirror .cm-scroller {
+        height: 100% !important;
+        overflow-y: auto !important;
     }
 }
 


### PR DESCRIPTION
This PR attempts to lock down the height of the codemirror element. Even during my testing I still was having some issues but this was as close as I could get until a core solution is introduced. Alternatively we could open a much larger window just for the macro editor but that's a lot of extra clicks.