### PR TITLE
Resistance (Modern) 1.0.2

### DIFF
--- a/lang/cs.json
+++ b/lang/cs.json
@@ -114,6 +114,7 @@
             "Activities": "Aktivity:",
             "AffectAllies": "Mělo by to ovlivnit spojence:",
             "AllowEnemies": "Povolit výběr NEpřátelských tokenů?",
+            "AllowMultiplePerTurn" : "Povolit více použití za tah?",
             "Animation": "Animace:",
             "Animations": {
                 "Air": "Vzdušná",

--- a/lang/en.json
+++ b/lang/en.json
@@ -114,6 +114,7 @@
             "Activities": "Activities:",
             "AffectAllies": "Should Affect Allies:",
             "AllowEnemies": "Allow selection of non-allied tokens?",
+            "AllowMultiplePerTurn" : "Allow Multiple Uses Per Turn?",
             "Animation": "Animation:",
             "Animations": {
                 "Air": "Air",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -165,6 +165,7 @@
             "AffectAllies": "Doit affecter les alliés :",
             "AvatarImgPriority": "Priorité à l'image d'Avatar :",
             "AllowEnemies": "Permettre la sélection de jetons non alliés ?",
+            "AllowMultiplePerTurn" : "Autoriser plusieurs utilisations par tour ?",
             "SpellSchools": "Écoles de magie :",
             "FailedSave": "Échec de la sauvegarde :",
             "TokenColor": "Couleur du token :",

--- a/lang/it.json
+++ b/lang/it.json
@@ -101,6 +101,7 @@
             "Ability": "Caratteristica:",
             "AffectAllies": "Dovrebbe Influenzare gli Alleati:",
             "AllowEnemies": "Consentire la selezione di token non alleati?",
+            "AllowMultiplePerTurn" : "Consentire usi multipli per turno?",
             "Animation": "Animazione:",
             "Animations": {
                 "Air": "Aria",

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -114,6 +114,7 @@
             "Activities": "Atividades:",
             "AffectAllies": "Deve Afetar Aliados:",
             "AllowEnemies": "Permitir seleção de tokens não-aliados?",
+            "AllowMultiplePerTurn" : "Permitir várias utilizações por turno?",
             "Animation": "Animação:",
             "Animations": {
                 "Air": "Ar",

--- a/packData/cpr-spells-2024/Resistance_98Z81gVmbJB8rqHB.json
+++ b/packData/cpr-spells-2024/Resistance_98Z81gVmbJB8rqHB.json
@@ -1,0 +1,316 @@
+{
+  "name": "Resistance",
+  "system": {
+    "description": {
+      "value": "",
+      "chat": ""
+    },
+    "source": {
+      "custom": "",
+      "rules": "2024",
+      "revision": 1
+    },
+    "activation": {
+      "type": "action",
+      "condition": "",
+      "value": null
+    },
+    "duration": {
+      "value": "1",
+      "units": "minute"
+    },
+    "target": {
+      "affects": {
+        "choice": false,
+        "count": "1",
+        "type": "willing",
+        "special": ""
+      },
+      "template": {
+        "units": "ft",
+        "contiguous": false,
+        "type": ""
+      }
+    },
+    "range": {
+      "units": "touch",
+      "special": ""
+    },
+    "uses": {
+      "max": "",
+      "spent": 0,
+      "recovery": []
+    },
+    "level": 0,
+    "school": "abj",
+    "properties": [
+      "vocal",
+      "somatic",
+      "concentration"
+    ],
+    "materials": {
+      "value": "",
+      "consumed": false,
+      "cost": 0,
+      "supply": 0
+    },
+    "activities": {
+      "xTVjCOa2R0sDCLOD": {
+        "type": "utility",
+        "_id": "dnd5eactivity000",
+        "sort": 0,
+        "activation": {
+          "type": "",
+          "override": true,
+          "condition": ""
+        },
+        "consumption": {
+          "scaling": {
+            "allowed": false
+          },
+          "spellSlot": true,
+          "targets": []
+        },
+        "description": {
+          "chatFlavor": ""
+        },
+        "duration": {
+          "units": "inst",
+          "concentration": false,
+          "override": true
+        },
+        "effects": [],
+        "range": {
+          "units": "self",
+          "override": false
+        },
+        "target": {
+          "template": {
+            "contiguous": false,
+            "units": "ft"
+          },
+          "affects": {
+            "choice": false
+          },
+          "override": false,
+          "prompt": true
+        },
+        "uses": {
+          "spent": 0,
+          "recovery": [],
+          "max": ""
+        },
+        "roll": {
+          "prompt": false,
+          "visible": true,
+          "name": "Resistance Roll (1d4)",
+          "formula": "1d4"
+        },
+        "useConditionText": "",
+        "useConditionReason": "",
+        "effectConditionText": "",
+        "macroData": {
+          "name": "",
+          "command": ""
+        },
+        "ignoreTraits": {
+          "idi": false,
+          "idr": false,
+          "idv": false,
+          "ida": false,
+          "idm": false
+        },
+        "midiProperties": {
+          "ignoreTraits": [],
+          "triggeredActivityId": "none",
+          "triggeredActivityConditionText": "",
+          "triggeredActivityTargets": "targets",
+          "triggeredActivityRollAs": "self",
+          "autoConsume": false,
+          "forceConsumeDialog": "default",
+          "forceRollDialog": "default",
+          "forceDamageDialog": "default",
+          "confirmTargets": "default",
+          "autoTargetType": "any",
+          "autoTargetAction": "default",
+          "automationOnly": true,
+          "otherActivityCompatible": false,
+          "otherActivityAsParentType": true,
+          "identifier": "resistance-roll",
+          "displayActivityName": false,
+          "rollMode": "default",
+          "chooseEffects": false,
+          "toggleEffect": false,
+          "ignoreFullCover": false,
+          "removeChatButtons": "default",
+          "magicEffect": false,
+          "magicDamage": false,
+          "noConcentrationCheck": false,
+          "autoCEEffects": "none"
+        },
+        "isOverTimeFlag": false,
+        "overTimeProperties": {
+          "saveRemoves": true,
+          "preRemoveConditionText": "",
+          "postRemoveConditionText": ""
+        },
+        "otherActivityId": "none",
+        "otherActivityAsParentType": true,
+        "name": "Resistance Roll",
+        "img": "icons/dice/d4black.svg"
+      },
+      "6rgsKB7N4ux9vou2": {
+        "type": "utility",
+        "_id": "dnd5eactivity001",
+        "sort": 0,
+        "activation": {
+          "type": "action",
+          "override": false
+        },
+        "consumption": {
+          "scaling": {
+            "allowed": false
+          },
+          "spellSlot": true,
+          "targets": []
+        },
+        "description": {
+          "chatFlavor": ""
+        },
+        "duration": {
+          "units": "inst",
+          "concentration": false,
+          "override": false
+        },
+        "effects": [],
+        "range": {
+          "units": "self",
+          "override": false
+        },
+        "target": {
+          "template": {
+            "contiguous": false,
+            "units": "ft"
+          },
+          "affects": {
+            "choice": false
+          },
+          "override": false,
+          "prompt": true
+        },
+        "uses": {
+          "spent": 0,
+          "recovery": [],
+          "max": ""
+        },
+        "roll": {
+          "prompt": false,
+          "visible": false,
+          "name": "",
+          "formula": ""
+        },
+        "useConditionText": "",
+        "useConditionReason": "",
+        "effectConditionText": "",
+        "macroData": {
+          "name": "",
+          "command": ""
+        },
+        "ignoreTraits": {
+          "idi": false,
+          "idr": false,
+          "idv": false,
+          "ida": false,
+          "idm": false
+        },
+        "midiProperties": {
+          "ignoreTraits": [],
+          "triggeredActivityId": "none",
+          "triggeredActivityConditionText": "",
+          "triggeredActivityTargets": "targets",
+          "triggeredActivityRollAs": "self",
+          "autoConsume": false,
+          "forceConsumeDialog": "default",
+          "forceRollDialog": "default",
+          "forceDamageDialog": "default",
+          "confirmTargets": "default",
+          "autoTargetType": "any",
+          "autoTargetAction": "default",
+          "automationOnly": false,
+          "otherActivityCompatible": false,
+          "otherActivityAsParentType": true,
+          "identifier": "apply-resistance",
+          "displayActivityName": false,
+          "rollMode": "default",
+          "chooseEffects": false,
+          "toggleEffect": false,
+          "ignoreFullCover": false,
+          "removeChatButtons": "default",
+          "magicEffect": false,
+          "magicDamage": false,
+          "noConcentrationCheck": false,
+          "autoCEEffects": "none"
+        },
+        "isOverTimeFlag": false,
+        "overTimeProperties": {
+          "saveRemoves": true,
+          "preRemoveConditionText": "",
+          "postRemoveConditionText": ""
+        },
+        "otherActivityId": "none",
+        "otherActivityAsParentType": true,
+        "name": "Apply Resistance"
+      }
+    },
+    "identifier": "resistance",
+    "method": "spell",
+    "sourceClass": "paladin",
+    "prepared": 1
+  },
+  "type": "spell",
+  "img": "icons/magic/defensive/shield-barrier-deflect-teal.webp",
+  "effects": [],
+  "folder": null,
+  "flags": {
+    "dnd5e": {
+      "riders": {
+        "activity": []
+      }
+    },
+    "chris-premades": {
+      "info": {
+        "identifier": "resistance",
+        "version": "1.0.2",
+        "hasAnimation": true,
+        "source": "chris-premades",
+        "rules": "modern"
+      },
+      "macros": {
+        "midi": {
+          "actor": [
+            "resistance"
+          ],
+          "item": [
+            "resistance"
+          ]
+        }
+      },
+      "config": {
+        "allowMulti": false
+      },
+      "activityIdentifiers": {
+        "resistance": "dnd5eactivity001",
+        "resistanceRoll": "dnd5eactivity000"
+      },
+      "hiddenActivities": [
+        "resistanceRoll"
+      ],
+      "spellActivities": [
+        "resistanceRoll"
+      ]
+    },
+    "midi-qol": {}
+  },
+  "_id" : "98Z81gVmbJB8rqHB",
+  "_key": "!items!98Z81gVmbJB8rqHB"
+}

--- a/scripts/lib/constants.js
+++ b/scripts/lib/constants.js
@@ -669,6 +669,80 @@ function getToolNames() {
 function getFeatOptions() {
     return featOptions;
 }
+
+const DAMAGE_TYPES_TABLE = {
+    acid: {
+        color: 'green',
+        image: 'icons/magic/acid/projectile-faceted-glob.webp',
+        category: 'elemental'
+    },
+    bludgeoning: {
+        color: 'yellow',
+        image: 'icons/magic/earth/projectiles-stone-salvo-gray.webp',
+        category: 'physical'
+    },
+    cold: {
+        color: 'blue',
+        image: 'icons/magic/air/wind-tornado-wall-blue.webp',
+        category: 'elemental'
+    },
+    fire: {
+        color: 'red',
+        image: 'icons/magic/fire/beam-jet-stream-embers.webp',
+        category: 'elemental'
+    },
+    force: {
+        color: 'purple',
+        image: 'icons/magic/sonic/projectile-sound-rings-wave.webp',
+        category: 'arcane'
+    },
+    lightning: {
+        color: 'blue',
+        image: 'icons/magic/lightning/bolt-blue.webp',
+        category: 'elemental'
+    },
+    necrotic: {
+        color: 'green',
+        image: 'icons/magic/unholy/projectile-bolts-salvo-pink.webp',
+        category: 'divine'
+    },
+    piercing: {
+        color: 'yellow',
+        image: 'icons/skills/melee/strike-polearm-light-orange.webp',
+        category: 'physical'
+    },
+    poison: {
+        color: 'green',
+        image: 'icons/magic/death/skull-poison-green.webp',
+        category: 'elemental'
+    },
+    psychic: {
+        color: 'purple',
+        image: 'icons/magic/control/fear-fright-monster-grin-red-orange.webp',
+        category: 'arcane'
+    },
+    radiant: {
+        color: 'purple',
+        image: 'icons/magic/holy/projectiles-blades-salvo-yellow.webp',
+        category: 'divine'
+    },
+    slashing: {
+        color: 'yellow',
+        image: 'icons/skills/melee/strike-sword-gray.webp',
+        category: 'physical'
+    },
+    thunder: {
+        color: 'purple',
+        image: 'icons/magic/sonic/explosion-shock-wave-teal.webp',
+        category: 'elemental'
+    },
+    no: {
+        color: 'blue',
+        image: 'icons/svg/cancel.svg',
+        category: 'none'
+    }
+};
+
 export let constants = {
     packs,
     featurePacks,
@@ -715,5 +789,6 @@ export let constants = {
     getBaseRangedWeaponOptions,
     getToolNames,
     getFeatOptions,
-    modernFeaturePacks
+    modernFeaturePacks,
+    DAMAGE_TYPES_TABLE
 };

--- a/scripts/lib/utilities/dialogUtils.js
+++ b/scripts/lib/utilities/dialogUtils.js
@@ -277,34 +277,30 @@ async function selectSpellSlot(actor, title, content, {maxLevel = 9, minLevel = 
     if (no) inputs.push(['CHRISPREMADES.Generic.No', false]);
     return await buttonDialog(title, content, inputs, {displayAsRows: true, userId: userId});
 }
-async function selectDamageType(damageTypes, title, context, {addNo = false, userId = game.user.id} = {}) {
-    let images = {
-        acid: 'icons/magic/acid/projectile-faceted-glob.webp',
-        bludgeoning: 'icons/magic/earth/projectiles-stone-salvo-gray.webp',
-        cold: 'icons/magic/air/wind-tornado-wall-blue.webp',
-        fire: 'icons/magic/fire/beam-jet-stream-embers.webp',
-        force: 'icons/magic/sonic/projectile-sound-rings-wave.webp',
-        lightning: 'icons/magic/lightning/bolt-blue.webp',
-        necrotic: 'icons/magic/unholy/projectile-bolts-salvo-pink.webp',
-        piercing: 'icons/skills/melee/strike-polearm-light-orange.webp',
-        poison: 'icons/magic/death/skull-poison-green.webp',
-        psychic: 'icons/magic/control/fear-fright-monster-grin-red-orange.webp',
-        radiant: 'icons/magic/holy/projectiles-blades-salvo-yellow.webp',
-        slashing: 'icons/skills/melee/strike-sword-gray.webp',
-        thunder: 'icons/magic/sonic/explosion-shock-wave-teal.webp',
-        no: 'icons/svg/cancel.svg'
-    };
-    let buttons = damageTypes.map(i => {
-        let image = images[i] ?? 'icons/magic/symbols/question-stone-yellow.webp';
+
+async function selectDamageType(damageTypes,title,context,{addNo = false,userId = game.user.id,override = {}} = {}) {
+    const meta = genericUtils.getDamageTypeMeta(override);
+    const buttons = damageTypes.map(type => {
+        const image =
+            meta[type]?.image ??
+            'icons/magic/symbols/question-stone-yellow.webp';
+
         return [
-            CONFIG.DND5E.damageTypes[i].label,
-            i,
-            {image}
+            CONFIG.DND5E.damageTypes[type]?.label ?? genericUtils.titleCase(type),
+            type,
+            { image }
         ];
     });
-    if (addNo) buttons.push(['CHRISPREMADES.Generic.No', false, {image: images.no}]);
-    return await buttonDialog(title, context, buttons, {userId});
+    if (addNo) {
+        buttons.push([
+            'CHRISPREMADES.Generic.No',
+            false,
+            { image: meta.no?.image ?? 'icons/svg/cancel.svg' }
+        ]);
+    }
+    return buttonDialog(title, context, buttons, { userId });
 }
+
 async function queuedConfirmDialog(title, content, {actor, reason, userId} = {}) {
     let selection;
     if (userId !== game.user.id) {

--- a/scripts/lib/utilities/effectUtils.js
+++ b/scripts/lib/utilities/effectUtils.js
@@ -255,6 +255,16 @@ function getConditions(effect) {
     conditions = conditions.union(effect.statuses ?? new Set());
     return conditions;
 }
+
+async function killConcentration(actor, item) {
+    if (!actor) return genericUtils.logDetailed('dev', 'no actor provided:', actor);
+    let concentrationEffectToKill
+    if (!item) concentrationEffectToKill = effectUtils.getConcentrationEffect(actor);
+    else concentrationEffectToKill = effectUtils.getConcentrationEffect(actor,item);    
+    if (!concentrationEffectToKill) return genericUtils.logDetailed('dev', 'no concentration effect found for :', actor, 'and', item);
+    await genericUtils.remove(concentrationEffectToKill);
+}
+
 export let effectUtils = {
     getCastData,
     getCastLevel,
@@ -280,5 +290,6 @@ export let effectUtils = {
     createEffectFromSidebar,
     getOriginItem,
     getConditions,
-    getOriginItemSync
+    getOriginItemSync,
+    killConcentration
 };

--- a/scripts/lib/utilities/genericUtils.js
+++ b/scripts/lib/utilities/genericUtils.js
@@ -1,5 +1,5 @@
 import {socket, sockets} from '../sockets.js';
-import {socketUtils} from '../../utils.js';
+import {socketUtils, constants} from '../../utils.js';
 import * as legacyMacros from '../../legacyMacros.js';
 import * as modernMacros from '../../macros.js';
 let cachedSettings = {};
@@ -185,6 +185,44 @@ function convertDistance(ft) {
     if (canvas.scene.grid.units !== 'm') return ft;
     return Math.floor((ft / 5) * 1.5);
 }
+
+function sanitizeNumber(input, defaultValue = 0, { math = 'none' } = {}) {
+    if (!Number.isFinite(input)) {
+        log('error', `sanitizeNumber: input '${input}' is not finite; returning ${defaultValue}`);
+        return defaultValue;
+    }
+    switch (math) {
+        case 'none':
+            return input;
+        case 'ceil':
+            log('dev', `sanitizeNumber: applying ceil to ${input}`);
+            return Math.ceil(input);
+        case 'round':
+            log('dev', `sanitizeNumber: applying round to ${input}`);
+            return Math.round(input);
+        case 'floor':
+            log('dev', `sanitizeNumber: applying floor to ${input}`);
+            return Math.floor(input);
+        default:
+            log('warn', `sanitizeNumber: unknown math op '${math}', returning input unchanged`);
+            return input;
+    }
+}
+
+function getDamageTypeMeta(override = {}) {
+    const merged = {};
+    for (const [type, data] of Object.entries(constants.DAMAGE_TYPES_TABLE)) {
+        merged[type] = { ...data, ...(override[type] ?? {}) };
+    }
+    return merged;
+}
+
+function logDetailed(type, ...message) {
+    if (type === 'dev' && !getCPRSetting('devTools')) return;
+    if (type === 'dev') type = 'log';
+    console[type]('CPR:', ...message);
+}
+
 export let genericUtils = {
     sleep,
     translate,
@@ -219,5 +257,8 @@ export let genericUtils = {
     getRules,
     getCPRIdentifier,
     convertDistance,
-    getCPRIdentifiers
+    getCPRIdentifiers,
+    sanitizeNumber,
+    getDamageTypeMeta,
+    logDetailed
 };

--- a/scripts/lib/utilities/workflowUtils.js
+++ b/scripts/lib/utilities/workflowUtils.js
@@ -338,6 +338,135 @@ function addEntityRemoval(workflow, entities) {
     let current = workflow['chris-premades']?.removeEntityUuids ?? [];
     genericUtils.setProperty(workflow, 'chris-premades.removeEntityUuids', [...current, ...entities.map(i => i.uuid)]);
 }
+
+function modifyDamageItem(damageItem, damageInstance, newValue) {
+    if (!damageItem || !damageInstance) return;
+    genericUtils.logDetailed('dev',`old detail damage:`,damageItem, 'old damage instance:', damageInstance);
+    damageInstance.value = newValue;
+
+    if (damageInstance.active) {
+        damageInstance.active.modification = true;
+    }
+
+    const detail = Array.isArray(damageItem.damageDetail) ? damageItem.damageDetail : [];
+    let newTotalDamage = detail.reduce((sum, d) => {
+        const safeV = genericUtils.sanitizeNumber(d?.value ?? 0);
+        return sum + safeV;
+    }, 0);
+    genericUtils.log('dev',`new Total Damage: ${newTotalDamage}`);
+    damageItem.totalDamage = newTotalDamage;
+    workflowUtils.applyNewTotalDamage(damageItem, newTotalDamage);
+    genericUtils.logDetailed('dev',`new detail damage:`,damageItem, 'new damage instance:', damageInstance);
+}
+
+function calculateNewDamageValue({damageInstance, damageMod = 0, orderOfDamage = 'DRSaveDr'}) {
+
+    if (!damageInstance) return 0;
+
+    const base = genericUtils.sanitizeNumber(damageInstance.damage ?? 0);
+    const final = genericUtils.sanitizeNumber(damageInstance.value ?? 0);
+
+    const saved = damageInstance.active?.saved ?? false;
+    const resistant = damageInstance.active?.resistance ?? false;
+    const vulnerable = damageInstance.active?.vulnerability ?? false;
+    const immune = damageInstance.active?.immunity ?? false;
+
+    if (immune) return 0;
+
+    const saveMult = saved ? 0.5 : 1;
+    const resistMult = resistant ? 0.5 : 1;
+    const vulnMult = vulnerable ? 2 : 1;
+
+    const finalMultiplier = saveMult * resistMult * vulnMult;
+
+    // Compute customMods, a damage modification the multiplier may not reflect, such as system.traits.dm.amount.x
+    // it doesn't apply to specific dm.midi, which are added to the damageDetail Array so we don't need to compute it
+    let customMods = 0;
+    let newValue = 0;
+
+    if (orderOfDamage === 'DRSaveDr') {
+        // final = (base + customMods) * finalMultiplier
+        customMods = final / finalMultiplier - base;
+        genericUtils.log('dev',`customMod applied to damage was ${customMods}`);
+        // apply new mod
+        newValue = (base + customMods + damageMod) * finalMultiplier;
+    }
+    else {
+        // alternate order:
+        // final = ((base * saveMult) + customMods) * (resistMult * vulnMult)
+        const afterSave = base * saveMult;
+        const resistVulnMult = resistMult * vulnMult;
+
+        customMods = (final / resistVulnMult) - afterSave;
+        genericUtils.log('dev',`customMod applied to damage was ${customMods}`);
+
+        newValue = ((base * saveMult) + customMods + damageMod) * resistVulnMult;
+    }
+
+    newValue = Math.floor(newValue);
+
+    return newValue;
+}
+
+function applyNewTotalDamage(damageItem, newTotalDamage) {
+    genericUtils.logDetailed('dev', 'damageItem inspection:', damageItem, 'new TotalDamage:', newTotalDamage);
+    if (!damageItem) return;
+
+    const total = genericUtils.sanitizeNumber(newTotalDamage);
+    const roundedTotal = total > 0 ? Math.floor(total) : Math.ceil(total);
+
+    // Mirror Elwin helper if present
+    if (damageItem?.elwinHelpersEffectiveDamage !== undefined)
+        damageItem.elwinHelpersEffectiveDamage = roundedTotal;
+    
+    if (damageItem?.healingAdjustedTotalDamage !== undefined)
+        damageItem.healingAdjustedTotalDamage = roundedTotal;
+
+    // HP / Temp HP logic
+    const oldTemp = Math.max(0, genericUtils.sanitizeNumber(damageItem.oldTempHP ?? 0));
+    const oldHP = Math.max(0, genericUtils.sanitizeNumber(damageItem.oldHP ?? 0));
+
+    if (oldTemp >= roundedTotal) {
+        damageItem.newTempHP = oldTemp - roundedTotal;
+        damageItem.tempDamage = roundedTotal;
+        damageItem.hpDamage = 0;
+        damageItem.newHP = oldHP;
+    }
+    else if (oldTemp > 0) {
+        const hpDamage = Math.min(roundedTotal - oldTemp, oldHP);
+        damageItem.newTempHP = 0;
+        damageItem.tempDamage = oldTemp;
+        damageItem.hpDamage = hpDamage;
+        damageItem.newHP = Math.max(0, oldHP - hpDamage);
+    }
+    else {
+        const hpDamage = Math.min(roundedTotal, oldHP);
+        damageItem.newTempHP = 0;
+        damageItem.tempDamage = 0;
+        damageItem.hpDamage = hpDamage;
+        damageItem.newHP = Math.max(0, oldHP - hpDamage);
+    }
+};
+
+function getHighestDamageInstance(damageDetail = [], type = null) {
+    const entries = type
+        ? damageDetail.filter(d => d?.type === type)
+        : damageDetail;
+
+    if (!entries.length) return null;
+
+    return entries.reduce((max, d) =>
+        (d?.value ?? 0) > (max?.value ?? 0) ? d : max
+    , null);
+};
+
+function getTotalEffectiveDamageOfType(damageDetail, type) {
+    if (!Array.isArray(damageDetail)) return 0;
+    return damageDetail
+        .filter(d => d?.type === type && typeof d.value === 'number')
+        .reduce((total, d) => total + d.value, 0);
+}
+
 export let workflowUtils = {
     bonusDamage,
     bonusAttack,
@@ -365,5 +494,10 @@ export let workflowUtils = {
     getActionType,
     swapAttackAbility,
     addEntityRemoval,
-    preventDeath
+    preventDeath,
+    modifyDamageItem,
+    calculateNewDamageValue,
+    applyNewTotalDamage,
+    getHighestDamageInstance,
+    getTotalEffectiveDamageOfType
 };

--- a/scripts/macros.js
+++ b/scripts/macros.js
@@ -160,6 +160,7 @@ export {passWithoutTrace} from './macros/2024/spells/passWithoutTrace.js';
 export {powerWordHeal} from './macros/2024/spells/powerWordHeal.js';
 export {powerWordKill} from './macros/2024/spells/powerWordKill.js';
 export {protectionFromEvilAndGood} from './macros/2024/spells/protectionFromEvilAndGood.js';
+export {resistance} from './macros/2024/spells/resistance.js';
 export {sanctuary, sanctuarySafe} from './macros/2024/spells/sanctuary.js';
 export {scorchingRay} from './macros/2024/spells/scorchingRay.js';
 export {searingSmite} from './macros/2024/spells/searingSmite.js';

--- a/scripts/macros/2024/spells/resistance.js
+++ b/scripts/macros/2024/spells/resistance.js
@@ -1,0 +1,197 @@
+import {activityUtils, actorUtils,animationUtils, dialogUtils, effectUtils, genericUtils, itemUtils, workflowUtils} from '../../../utils.js';
+
+
+function resolveResistanceSource(effects, damageDetail) {
+    if (!effects?.length || !Array.isArray(damageDetail) || !damageDetail.length) {
+        return { effect: null, type: null, damageInstance: null };
+    }
+
+    const damageTypes = [...new Set(
+        effects.map(e => e.flags?.['chris-premades']?.info?.damageType).filter(Boolean)
+    )];
+
+    if (!damageTypes.length) {
+        genericUtils.log('dev', 'Resistances found, but none with a damageType flag.');
+        return { effect: null, type: null, damageInstance: null };
+    }
+
+    const totalsByType = damageTypes.map(type => ({
+        type,
+        total: workflowUtils.getTotalEffectiveDamageOfType(damageDetail, type) || 0
+    }));
+
+    genericUtils.logDetailed('dev', 'Totals by resistance type:', totalsByType);
+
+    const allZero = totalsByType.every(entry => entry.total === 0);
+    if (allZero) {
+        genericUtils.log('dev', 'No effective damage of any resistance type was taken.');
+        return { effect: null, type: null, damageInstance: null };
+    }
+
+    const highestType = totalsByType.sort((a, b) => b.total - a.total)[0].type;
+
+    genericUtils.log('dev', `Highest damage type is ${highestType}, resistance will apply to this type.`);
+
+    const effect = effects.find(
+        e => e.flags?.['chris-premades']?.info?.damageType === highestType
+    );
+    if (!effect) {
+        genericUtils.log('dev', 'Could not find a matching effect for highestType, this should not happen.');
+        return { effect: null, type: null, damageInstance: null };
+    }
+
+    const damageInstance = workflowUtils.getHighestDamageInstance(damageDetail, highestType);
+    if (!damageInstance) {
+        genericUtils.log('dev', 'No damageInstance found for highestType, this should not happen.');
+        return { effect: null, type: null, damageInstance: null };
+    }
+
+    return { effect, type: highestType, damageInstance };
+}
+
+async function playResistanceAnimation(targetToken, parentItem, damageType) {
+    let playAnimation = itemUtils.getConfig(parentItem, 'playAnimation') === true;
+    if (!playAnimation) return genericUtils.log('dev', 'Animation disabled in config');
+    if (!targetToken) return genericUtils.log('dev', 'no target token found to play animation');;
+    if (animationUtils.jb2aCheck() !== 'patreon') return genericUtils.log('dev', `patreon J2BA not detected`);
+    const META = genericUtils.getDamageTypeMeta();
+    genericUtils.logDetailed('dev', 'damageType', damageType, 'color', META[damageType]?.color)
+    const effectColor = META[damageType]?.color ?? 'blue';
+    new Sequence()
+        .effect()
+            .attachTo(targetToken)        
+            .file(`jb2a.shield.01.complete.01.${effectColor}`)
+            .scaleToObject(1.5 * targetToken.document.texture.scaleX)
+            .fadeIn(0, {ease: 'easeOutCubic'})
+            .fadeOut(1000, {ease: 'easeOutCubic'})
+            .name('resistance')
+            .play();
+}
+
+async function use({trigger, workflow}) {
+    const META = genericUtils.getDamageTypeMeta();
+
+    const ALLOWED = ['elemental', 'physical', 'divine'];
+
+    const FILTERED_TYPES = Object.keys(META).filter(
+        type => ALLOWED.includes(META[type].category)
+    );
+    const type = await dialogUtils.selectDamageType(
+        FILTERED_TYPES,
+        workflow.activity.name,
+        'CHRISPREMADES.Generic.SelectDamageType', { addNo:true }
+    );
+    genericUtils.log('dev',`Type ${type} chosen, apply effect to target.`);
+    if (!type) {
+      await effectUtils.killConcentration(workflow?.actor, workflow?.item);
+      return;
+    }
+    const targetToken = workflow?.targets?.values().next().value;
+    if (!targetToken) {
+      genericUtils.log('dev','no target found, exiting...')
+      await effectUtils.killConcentration(workflow?.actor, workflow?.item)
+      return;
+    } 
+    const effectData = {
+        name: `Resistance (${genericUtils.titleCase(type)})`,
+        img: META[type]?.image ?? workflow.item.img,
+        origin: workflow.item.uuid,
+        duration: itemUtils.convertDuration(workflow.item),
+        flags: {
+            'chris-premades': {
+                info: {
+                    identifier: 'resistance',
+                    damageType: type
+                }
+            }
+        },
+    };
+    genericUtils.logDetailed('dev',`effect`, effectData);
+    await effectUtils.createEffect(targetToken?.actor, effectData, {concentrationItem: workflow?.item})
+}
+
+// ** Damage Reduction Application ** //
+async function damageApplication({ trigger: { token }, workflow, ditem }) {
+
+    const actor = token?.actor;
+    const damageDetail = ditem?.damageDetail;
+    if (!actor || !Array.isArray(damageDetail) || !damageDetail.length) return;
+
+
+    const effects = effectUtils.getAllEffectsByIdentifier(actor, 'resistance') ?? [];
+    if (!effects.length) return;
+
+    const { effect: sourceEffect, type: resistanceType, damageInstance } =
+      resolveResistanceSource(effects, damageDetail);
+
+    if (!sourceEffect || !resistanceType || !damageInstance) {
+      return genericUtils.log('dev', 'No applicable resistance for this hit.');
+    }
+
+    const originDoc = sourceEffect.origin ? await fromUuid(sourceEffect.origin) : null;
+    const parentCaster = originDoc?.parent;
+    if (!parentCaster) return genericUtils.log('error','no parent caster found');
+
+    const parentItem = await itemUtils.getItemByIdentifier(parentCaster, 'resistance');
+    if (!parentItem) return;
+
+    const alreadyUsed = await itemUtils.perTurnUsage(parentItem, token?.actor, false);
+    genericUtils.log('dev',`alreadyUsed ${alreadyUsed}`);
+    if (alreadyUsed) return;
+
+    const rollActivity = activityUtils.getActivityByIdentifier(parentItem, 'resistanceRoll', {strict : true});
+    genericUtils.logDetailed('dev','rollActivity',rollActivity);
+    if (!rollActivity) return genericUtils.log('error','no roll activity found');
+
+    const rollData = await workflowUtils.syntheticActivityDataRoll(rollActivity,parentItem,actor,[actorUtils.getFirstToken(actor)]);
+
+    await playResistanceAnimation(actorUtils.getFirstToken(actor), parentItem, resistanceType)
+    const oldValue = genericUtils.sanitizeNumber(damageInstance.value)
+    const newValue = workflowUtils.calculateNewDamageValue({damageInstance : damageInstance, damageMod : -(rollData?.utilityRolls?.[0]?.total ?? 0), orderOfDamage : game.settings.get('midi-qol', 'ConfigSettings')?.saveDROrder ?? 'DRSaveDr'});
+
+    // If nothing actually changed, don't bother mutating the ditem but mark as used (the spell is not guaranteed to reduce damage, just guaranteed to try)
+    await itemUtils.perTurnUsage(parentItem, token?.actor, true);
+    if (newValue - oldValue === 0) return;
+
+    workflowUtils.modifyDamageItem(ditem, damageInstance, newValue);
+}
+
+export let resistance = {
+    name: 'Resistance',
+    version: '1.0.2',
+    rules: 'modern',
+    midi: {
+        item : [
+            { 
+                pass: 'preambleComplete', 
+                macro : use, 
+                priority : 50,
+                activities: ['resistance']
+            }
+        ],
+        actor: [
+            {
+                pass : 'targetApplyDamage', 
+                macro : damageApplication, 
+                priority : 50
+            },
+        ]
+    },
+    config: [
+        {
+            value: 'allowMulti',
+            label: 'CHRISPREMADES.Config.AllowMultiplePerTurn',
+            type: 'checkbox',
+            default: false,
+            homebrew: true,
+            category: 'homebrew'
+        },
+        {
+            value: 'playAnimation',
+            label: 'CHRISPREMADES.Config.PlayAnimation',
+            type: 'checkbox',
+            default: true,
+            category: 'animation'
+        }
+    ]
+};


### PR DESCRIPTION
# Resistance Modern

## Compendium

New Spell, Resistance (2024), `Resistance_98Z81gVmbJB8rqHB.json` added to `cpr-spells-2024`.

## Macro

### Macro passes
The script `resistance.js` has been added to `scripts/macros/2024/spells`.
* Uses `preambleComplete` on an item pass to apply an effect generated on the fly to the target of the spell. Uses CPR Flags `identifier` and add a `damageType` flag to identify the damage type(s) that is(are) available for resistance.
* Uses `targetApplyDamage` on an actor pass to check if the damage can be reduced, and compute the damage resistance manually via helpers made available globally (see below for description)

### Animation
* If damage is resisted, uses JB2A patreon animation, colored based on the damage resisted. Uses a mapping built from a new helper in `genericUtils`, see below for details.

### Configuration
* As per RAW, the actor is only allowed one use per turn, irrelevant of how many Resistance effects currently applied. If several effects applied, the effect reducing damage from the highest source of *effective* damage will be chosen. A homebrew config, `allowMulti` (see below) is available for tables who might find it useful given the relative weakness of the spell vs other spells of similar function and level such as Blade Ward.  
* Animation can be deactivated, they ignore non patreon users similarly to other CPR macros.

# Changes

I was not sure of the philosophy of CPR. Whether macros should be mostly self reliant, or if it was preferred to build helpers that could benefit all future macros. I've decided to lean on the latter.

## Lang

`CHRISPREMADES.Config.AllowMultiplePerTurn` added to `en.json`, `cs.json`, `fr.json`, `pr-BT.json` and `it.json`, with machine translations added for non english users.


## Helpers Modified


### dialogUtils.selectDamageType

I wanted to provide a CPR icon to my resistance effect, for consistency. From a UX perspective, choosing `acid`, with icon `'icons/magic/acid/projectile-faceted-glob.webp'` and having an effect using a different icon would feel inconsistent in my view. So I started copying and using the same table than `selectDamageType`. But then every macro needing it having to copy paste the table? It felt redundant, so I built a helper for that, `genericUtils.getDamageTypeMeta`, alongside a more complex lookup table `constants.DAMAGE_TYPES` presenting damage category, image and color (which is conveniently used by the animation). I've made sure it was backward compatible so nothing using `dialogUtils.selectDamageType` will see the difference, and future macro may make use of the new helper. 

The helper allows overrides, would a contributor wants to use different images, or colors...

## Constants added

### constants.DAMAGE_TYPES

New CONST presenting a lookup table of generic damage type, associating categories to them as well as color to work alongside `dialogUtils.selectDamageType`
Categories available are physical, elemental, divine and arcane. Divine (Radiant & Necrotic) and Arcane (Psychic & Force) were honestly the least obvious to define, since few abilities can grant access to radiant / necrotic and psychic but not force, or the other way around.

## Helpers added

### genericUtils

#### genericUtils.logDetailed

The existing implemention of log cast everything to a single string, which can make objects impossible to inspect properly. This helper accepts objects. I would have modified the genericUtils.log but thought adding a different first could be preferred. 

#### genericUtils.getDamageTypeMeta

New helper simply wrapping the new looking table `constants.DAMAGE_TYPES` and presenting it to `dialogUtils.selectDamageType`. Can be overridden as needed via the `override` variable in `selectDamageType` or directly in `getDamageTypeMeta`.

#### effectUtils.killConcentration

New helper that can either kill any concentration item on an actor, or kill concentration based on the item provided on an actor. 

#### genericUtils.sanitizeNumber

Simple helper to ensure a Number is valid and gracefully fallback if not with error logging to console via `genericUtils.log("error","x")`. 

### itemUtils

#### itemUtils.perTurnUsage

A simple helper to check if an item is used this turn, optionally mark it as used with support for the new `allowMulti` config (labelled `CHRISPREMADES.Config.AllowMultiplePerTurn`) flag to allow multiple usage. Uses `combatUtils.perTurnCheck`, `combatUtils.setTurnCheck` and `itemUtils.getConfig`. `combatUtils` is now imported by `itemUtils`

### workflowUtils

*Damage modification* 

I couldn't find a damage modification helper that did what I needed. `system.dm.amount.x` required the effect to be set before any damage calculation happens, which made the macro a bit too convoluted. 
`workflowUtils.modifyDamageAppliedFlat` wouldn't reduce the damage, just add more, which didn't work. So rather than trying to modify an existing helper and potentially break a lot of stuff, I created new helpers. 

#### workflowUtils.modifyDamageItem

A helper to mutate the damage item in place. 

#### workflowUtils.calculateNewDamageValue

A helper to calculate the new damage value based on MIDI order of damage. Doesn't mutate anything.

#### workflowUtils.applyNewTotalDamage

A helper to adjust the total damage taken based on temp HP, healing, etc. It has been tested in various conditions to ensure MIDI doesn't complain about ignoring HP Damage. Compatible with Elwin Helpers if present in the damage item. 

#### workflowUtils.getHighestDamageInstance

A simple helper to get the highest damage item in a damage detail array, based on the effective damage rather than total. Accepts arguments to limit search to specific type only.

#### workflowUtils.getTotalEffectiveDamageOfType

Return the effective damage of a single damage type based on the MIDI QOL calculated value.

## Import added

`combatUtils` import was added to `itemUtils.js` to support the new helper `itemUtils.perTurnUsage`

`constants` import was added to `genericUtils.js`

## Final note

It has been a real treat to work with such a great code base as CPR. So irrelevant of the final decision, I've really enjoyed it. Thanks for making this superb module.

