### PR TITLE
bug-fix: Casting Conjure Woodland Beings out of combat triggers an er…

### DIFF
--- a/scripts/lib/utilities/combatUtils.js
+++ b/scripts/lib/utilities/combatUtils.js
@@ -1,32 +1,41 @@
 function currentTurn() {
-    return game.combat.round + '-' + game.combat.turn;
+    if (!inCombat()) return undefined;
+    const {round, turn} = game.combat;
+    return `${round}-${turn}`;
 }
+
 function inCombat() {
     return !!game.combat;
 }
+
 function combatStarted() {
     if (!inCombat()) return false;
     return game.combat.started;
 }
+
 function perTurnCheck(entity, name, ownTurnOnly, tokenId) {
     if (!inCombat()) return true;
     if (ownTurnOnly && (tokenId !== game.combat.current.tokenId)) return false;
     let previousTurn = entity.flags['chris-premades']?.[name]?.turn;
     return currentTurn() !== previousTurn;
 }
+
 async function setTurnCheck(entity, name, reset) {
-    let turn = '';
-    if (combatUtils.inCombat() && !reset) turn = game.combat.round + '-' + game.combat.turn;
-    await entity.setFlag('chris-premades', name + '.turn', turn);
+    let turn = currentTurn();
+    if (reset || !turn) turn = '';
+    await entity.setFlag('chris-premades', `${name}.turn`, turn);
 }
+
 function getCurrentCombatantToken() {
     let currCombatant = game.combat?.combatants.get(game.combat?.current?.combatantId);
     return game.scenes.get(currCombatant?.sceneId)?.tokens.get(currCombatant?.tokenId)?.object;
 }
+
 function isOwnTurn(token) {
     if (!inCombat()) return true;
     return token.document.id === game.combat.current.tokenId;
 }
+
 export let combatUtils = {
     currentTurn,
     inCombat,

--- a/scripts/macros/2024/spells/conjureAnimals.js
+++ b/scripts/macros/2024/spells/conjureAnimals.js
@@ -63,8 +63,7 @@ async function use({workflow}) {
         }
     });
     let nearbyTargets = tokenUtils.findNearby(spawnedToken, 10, 'enemy');
-    let turnToCheck;
-    if (combatUtils.inCombat()) turnToCheck = combatUtils.currentTurn();
+    let turnToCheck = combatUtils.currentTurn();
     await saveHelper(nearbyTargets, summonedEffect, spawnedToken.object, turnToCheck);
 }
 async function save({trigger: {entity: effect, token, saveId, options}}) {
@@ -84,8 +83,7 @@ async function moved({trigger: {token, entity: effect}, options}) {
     let radius = 10 + token.document.width * canvas.grid.distance;
     let affectedTokens = tokenUtils.getMovementHitTokens(startPoint, endPoint, radius, {includeAlreadyHit: true});
     affectedTokens = Array.from(affectedTokens).filter(t => t.actor && !MidiQOL.checkIncapacitated(t.actor) && token.document.disposition !== t.document.disposition);
-    let turnToCheck;
-    if (combatUtils.inCombat()) turnToCheck = combatUtils.currentTurn();
+    let turnToCheck = combatUtils.currentTurn();
     await saveHelper(affectedTokens, effect, token, turnToCheck);
 }
 async function turnEnd({trigger: {token, target, entity: effect, previousTurn, previousRound}}) {
@@ -93,8 +91,7 @@ async function turnEnd({trigger: {token, target, entity: effect, previousTurn, p
     await saveHelper([target], effect, token, turnToCheck);
 }
 async function movedNear({trigger: {token, target, entity: effect}}) {
-    let turnToCheck;
-    if (combatUtils.inCombat()) turnToCheck = combatUtils.currentTurn();
+    let turnToCheck = combatUtils.currentTurn();
     await saveHelper([target], effect, token, turnToCheck);
 }
 async function saveHelper(affectedTokens, effect, token, turnToCheck) {

--- a/scripts/macros/2024/spells/conjureWoodlandBeings.js
+++ b/scripts/macros/2024/spells/conjureWoodlandBeings.js
@@ -29,8 +29,7 @@ async function use({workflow}) {
         rules: 'modern'
     });
     let nearbyTokens = tokenUtils.findNearby(workflow.token, 10, 'enemy');
-    let turnToCheck;
-    if (combatUtils.inCombat()) turnToCheck = combatUtils.currentTurn();
+    let turnToCheck = combatUtils.currentTurn();
     await damageHelper(nearbyTokens, effect, workflow.token, turnToCheck);
 }
 async function moved({trigger: {token, entity: effect}, options}) {
@@ -41,8 +40,7 @@ async function moved({trigger: {token, entity: effect}, options}) {
     let endPoint = {x: token.center.x, y: token.center.y};
     let radius = 10 + token.document.width * canvas.grid.distance;
     let affectedTokens = Array.from(tokenUtils.getMovementHitTokens(startPoint, endPoint, radius)).filter(t => t.document.disposition !== token.document.disposition);
-    let turnToCheck;
-    if (combatUtils.inCombat()) turnToCheck = combatUtils.currentTurn();
+    let turnToCheck = combatUtils.currentTurn();
     await damageHelper(affectedTokens, effect, token, turnToCheck);
 }
 async function turnEnd({trigger: {token, target, entity: effect, previousTurn, previousRound}}) {
@@ -61,8 +59,7 @@ async function movedNear({trigger: {target, token, entity: effect}, options}) {
     }, {parent: canvas.scene});
     let oldDistance = tokenUtils.getDistance(token, tempToken);
     if (oldDistance <= 10) return;
-    let turnToCheck;
-    if (combatUtils.inCombat()) turnToCheck = combatUtils.currentTurn();
+    let turnToCheck = combatUtils.currentTurn();
     await damageHelper([target], effect, token, turnToCheck);
 }
 async function damageHelper(affectedTokens, effect, token, turnToCheck) {


### PR DESCRIPTION
…ror.

       V--- Always true since this is a function
if (combatUtils.inCombat) turnToCheck = combatUtils.currentTurn();
                                                 ^--- Generates an error since not in combat

Addressed this issue by doing a few things:
1. Added a if (!inCombat()) return undefined; to currentTurn to explicitly give a return
2. Examined all current usages of combatUtils.currentTurn to ensure compliance
3. Updated conjureAnimals and conjureWoodlandBeings utilizing this new return to simplify code

Additional cleanup:
1. Added function documentation to all functions in combatUtils.js
2. Refactored the logic on setTurnCheck to utilize the currentTurn function.

Bug-Id: 475