### PR TITLE
Hunger Of Hadar, legacy + modern. 

### DIFF
--- a/scripts/macros/2014/spells/hungerOfHadar.js
+++ b/scripts/macros/2014/spells/hungerOfHadar.js
@@ -41,7 +41,33 @@ async function use({workflow}) {
             'chris-premades': {
                 conditions: ['blinded']
             }
-        }
+        },
+        changes: [
+            {
+                key: 'system.attributes.movement.walk',
+                mode: CONST.ACTIVE_EFFECT_MODES.MULTIPLY,
+                value: 0.5
+            },
+            {
+                key: 'system.attributes.movement.fly',
+                mode: CONST.ACTIVE_EFFECT_MODES.MULTIPLY, value: 0.5
+            },
+            {
+                key: 'system.attributes.movement.swim',
+                mode: CONST.ACTIVE_EFFECT_MODES.MULTIPLY,
+                value: 0.5
+            },
+            {
+                key: 'system.attributes.movement.climb',
+                mode: CONST.ACTIVE_EFFECT_MODES.MULTIPLY,
+                value: 0.5
+            },
+            {
+                key: 'system.attributes.movement.burrow',
+                mode: CONST.ACTIVE_EFFECT_MODES.MULTIPLY,
+                value: 0.5
+            }
+        ]
     };
     for (let target of targets) await effectUtils.createEffect(target.actor, effectData, {parentEntity: template, identifier: 'hungerOfHadarBlinded'});
 }

--- a/scripts/macros/2024/spells/hungerOfHadar.js
+++ b/scripts/macros/2024/spells/hungerOfHadar.js
@@ -62,7 +62,33 @@ async function use({workflow}) {
             'chris-premades': {
                 conditions: ['blinded']
             }
-        }
+        },
+        changes: [
+            {
+                key: 'system.attributes.movement.walk',
+                mode: CONST.ACTIVE_EFFECT_MODES.MULTIPLY,
+                value: 0.5
+            },
+            {
+                key: 'system.attributes.movement.fly',
+                mode: CONST.ACTIVE_EFFECT_MODES.MULTIPLY, value: 0.5
+            },
+            {
+                key: 'system.attributes.movement.swim',
+                mode: CONST.ACTIVE_EFFECT_MODES.MULTIPLY,
+                value: 0.5
+            },
+            {
+                key: 'system.attributes.movement.climb',
+                mode: CONST.ACTIVE_EFFECT_MODES.MULTIPLY,
+                value: 0.5
+            },
+            {
+                key: 'system.attributes.movement.burrow',
+                mode: CONST.ACTIVE_EFFECT_MODES.MULTIPLY,
+                value: 0.5
+            }
+        ]
     };
     for (let target of targets) await effectUtils.createEffect(target.actor, effectData, {
         parentEntity: template,


### PR DESCRIPTION
Halved all type of movement (the area is difficult terrain) on both modern and legacy version, via the already existing "blinded" effect for convenience and simplicity.

Using the spell at a table recently I realized CPR wasn't automating this. I've added this specific change to my table. There might have been a very good reason why it was not done. If so, my apologies for wasting your time.

Best