### PR TITLE
Orc Relentless Endurance for Modern

### DIFF
--- a/packData/cpr-species-features-2024/Orc_UU6l4hcTpV0kx2FW.json
+++ b/packData/cpr-species-features-2024/Orc_UU6l4hcTpV0kx2FW.json
@@ -1,0 +1,11 @@
+{
+  "type": "Item",
+  "folder": null,
+  "name": "Orc",
+  "color": null,
+  "sorting": "a",
+  "_id": "UU6l4hcTpV0kx2FW",
+  "description": "",
+  "flags": {},
+  "_key": "!folders!UU6l4hcTpV0kx2FW"
+}

--- a/packData/cpr-species-features-2024/Relentless_Endurance_0qoCc5hRNvkkASxn.json
+++ b/packData/cpr-species-features-2024/Relentless_Endurance_0qoCc5hRNvkkASxn.json
@@ -1,0 +1,200 @@
+{
+  "name": "Relentless Endurance",
+  "type": "feat",
+  "effects": [],
+  "system": {
+    "activities": {
+      "utilRelEndurRace": {
+        "type": "utility",
+        "_id": "utilRelEndurRace",
+        "sort": 0,
+        "activation": {
+          "type": "special",
+          "value": 1,
+          "condition": "",
+          "override": false
+        },
+        "consumption": {
+          "targets": [
+            {
+              "type": "itemUses",
+              "target": "",
+              "value": "1",
+              "scaling": {
+                "mode": "",
+                "formula": ""
+              }
+            }
+          ],
+          "scaling": {
+            "allowed": false,
+            "max": ""
+          },
+          "spellSlot": true
+        },
+        "description": {},
+        "duration": {
+          "units": "inst",
+          "special": "",
+          "concentration": false,
+          "override": false
+        },
+        "effects": [],
+        "range": {
+          "units": "self",
+          "special": "",
+          "override": false
+        },
+        "target": {
+          "prompt": true,
+          "affects": {
+            "count": "",
+            "type": "",
+            "choice": false,
+            "special": ""
+          },
+          "template": {
+            "count": "",
+            "contiguous": false,
+            "type": "",
+            "size": "",
+            "width": "",
+            "height": "",
+            "units": "ft"
+          },
+          "override": false
+        },
+        "uses": {
+          "spent": 0,
+          "recovery": []
+        },
+        "roll": {
+          "prompt": false,
+          "visible": false
+        },
+        "useConditionText": "",
+        "useConditionReason": "",
+        "effectConditionText": "",
+        "macroData": {
+          "name": "",
+          "command": ""
+        },
+        "ignoreTraits": {
+          "idi": false,
+          "idr": false,
+          "idv": false,
+          "ida": false,
+          "idm": false
+        },
+        "midiProperties": {
+          "ignoreTraits": [],
+          "triggeredActivityId": "none",
+          "triggeredActivityConditionText": "",
+          "triggeredActivityTargets": "targets",
+          "triggeredActivityRollAs": "self",
+          "confirmTargets": "default",
+          "automationOnly": false,
+          "identifier": "",
+          "triggeredActivityConsume": true,
+          "triggeredActivityConfigure": true,
+          "autoConsume": false,
+          "forceConsumeDialog": "default",
+          "forceRollDialog": "default",
+          "forceDamageDialog": "default",
+          "autoTargetType": "any",
+          "autoTargetAction": "default",
+          "otherActivityCompatible": true,
+          "otherActivityAsParentType": true,
+          "displayActivityName": false,
+          "rollMode": "default",
+          "chooseEffects": false,
+          "toggleEffect": false,
+          "ignoreFullCover": false,
+          "removeChatButtons": "default",
+          "magicEffect": false,
+          "magicDamage": false,
+          "noConcentrationCheck": false,
+          "skipConcentrationCheck": false,
+          "autoCEEffects": "default"
+        },
+        "isOverTimeFlag": false,
+        "overTimeProperties": {
+          "saveRemoves": true,
+          "preRemoveConditionText": "",
+          "postRemoveConditionText": ""
+        },
+        "otherActivityId": "none",
+        "otherActivityAsParentType": true
+      }
+    },
+    "uses": {
+      "spent": 0,
+      "max": "1",
+      "recovery": [
+        {
+          "period": "lr",
+          "type": "recoverAll"
+        }
+      ]
+    },
+    "advancement": {},
+    "description": {
+      "value": "",
+      "chat": ""
+    },
+    "identifier": "relentless-endurance",
+    "source": {
+      "book": "PHB 2024",
+      "page": "",
+      "license": "",
+      "custom": "",
+      "rules": "2024",
+      "revision": 1
+    },
+    "crewed": false,
+    "enchant": {},
+    "prerequisites": {
+      "items": [],
+      "repeatable": false
+    },
+    "properties": [],
+    "requirements": "",
+    "type": {
+      "value": "race",
+      "subtype": ""
+    }
+  },
+  "flags": {
+    "species": {
+      "fullRaceName": "Orc",
+      "baseRaceName": "Orc",
+      "groupName": "Orc",
+      "isLineage": false
+    },
+    "dnd5e": {
+      "advancementOrigin": "U1xoJGwPlyHli6WW",
+      "riders": {
+        "activity": []
+      }
+    },
+    "chris-premades": {
+      "info": {
+        "identifier": "relentlessEndurance",
+        "rules": "modern",
+        "source": "chris-premades",
+        "version": "1.5.21"
+      },
+      "macros": {
+        "midi": {
+          "actor": [
+            "relentlessEndurance"
+          ]
+        }
+      }
+    }
+  },
+  "img": "icons/magic/death/undead-zombie-grave-green.webp",
+  "folder": "UU6l4hcTpV0kx2FW",
+  "_id": "0qoCc5hRNvkkASxn",
+  "_key": "!items!0qoCc5hRNvkkASxn"
+}

--- a/scripts/macros.js
+++ b/scripts/macros.js
@@ -262,7 +262,7 @@ export {healingHands} from './macros/2024/speciesFeatures/aasimar/healingHands.j
 export {celestialRevelation, celestialRevelationInnerRadiance} from './macros/2024/speciesFeatures/aasimar/celestialRevelation.js';
 export {celestialResistance} from './macros/2024/speciesFeatures/aasimar/celestialResistance.js';
 // Orc
-export {relentlessEndurance} from './macros/2014/raceFeatures/orc/relentlessEndurance.js';
+export {relentlessEndurance} from './macros/2024/speciesFeatures/orc/relentlessEndurance.js';
 // Class Features
 // Artificer
 export {battleReady} from './macros/2024/classFeatures/artificer/battleReady.js';

--- a/scripts/macros.js
+++ b/scripts/macros.js
@@ -261,6 +261,8 @@ export {sangromanticInitiate} from './macros/2024/feats/sangromanticInitiate.js'
 export {healingHands} from './macros/2024/speciesFeatures/aasimar/healingHands.js';
 export {celestialRevelation, celestialRevelationInnerRadiance} from './macros/2024/speciesFeatures/aasimar/celestialRevelation.js';
 export {celestialResistance} from './macros/2024/speciesFeatures/aasimar/celestialResistance.js';
+// Orc
+export {relentlessEndurance} from './macros/2014/raceFeatures/orc/relentlessEndurance.js';
 // Class Features
 // Artificer
 export {battleReady} from './macros/2024/classFeatures/artificer/battleReady.js';

--- a/scripts/macros/2024/speciesFeatures/orc/relentlessEndurance.js
+++ b/scripts/macros/2024/speciesFeatures/orc/relentlessEndurance.js
@@ -1,0 +1,6 @@
+import {relentlessEndurance as relentlessEnduranceLegacy} from '../../../../legacyMacros.js';
+export let relentlessEndurance = {
+    ...relentlessEnduranceLegacy,
+    version: '1.5.21',
+    rules: 'modern'
+}


### PR DESCRIPTION
Existing Relentless Endurance Legacy macro can now be used for Modern.
Tested with dnd5e v5.3.1 on Foundry 13.351 and confirmed it worked:
<img width="342" height="306" alt="ModernCompendiumEntry" src="https://github.com/user-attachments/assets/4cbd7977-b578-4aa5-bab9-4a464f4eda15" />
<img width="869" height="372" alt="ModernRelentlessEndurance" src="https://github.com/user-attachments/assets/7aed16d7-ca6f-4357-8810-2dedbf176a8a" />
