### PR TITLE
Enable hands-off hybrid play on a communal display

### DIFF
--- a/lang/cs.json
+++ b/lang/cs.json
@@ -81,7 +81,7 @@
                     "Content": "Zvol cíl akce ",
                     "Title": "Výběr cíle"
                 }
-            } 
+            }
         },
         "CommonFeatures": {
             "Amphibious": "Obojživelník",
@@ -432,7 +432,7 @@
                 },
                 "movedNear": {
                     "Label": "Se pohnul/a blízko"
-                },    
+                },
                 "movedScene": {
                     "Label": "Scéna: Se pohnul/a"
                 },
@@ -473,7 +473,7 @@
                     "Label": "Bonus scény"
                 },
                 "sceneCreate": {
-                    "Label": "Vytvořeno scénou"              
+                    "Label": "Vytvořeno scénou"
                 },
                 "sceneDamageRollComplete": {
                     "Label": "Hod na zásah scény dokončen"
@@ -545,7 +545,7 @@
                     "Label": "Konec příštího tahu"
                 },
                 "turnEndSource": {
-                    "Label": "Konec tahu zdroje"    
+                    "Label": "Konec tahu zdroje"
                 },
                 "turnStart": {
                     "Label": "Začátek tahu"
@@ -3278,11 +3278,11 @@
             "manualRollsUsers": {
                 "Hint": "Nastaví, kteří uživatelé používají ruční hody.",
                 "Name": "Uživatelé ručních hodů"
-            },            
+            },
             "matchSummonElevation": {
                 "Hint": "Pokud je zaškrtnuto, pak budou tokeny přivolávané pomocí CPR vytvářeny ve stejné výšce jako token přivolávače.",
                 "Name": "Sjednotit výšku při přivolaní?"
-            },         
+            },
             "migrationVersion": {
                 "Hint": "Verze migrace",
                 "Name": "Verze migrace"
@@ -3330,6 +3330,10 @@
             "playerSelectsConjures": {
                 "Hint": "Při sesílání kouzel 'Vyvolej X' může hráč (nikoliv PJ) vybrat, jaké bytosti budou vyvolány.",
                 "Name": "Může hráč vybírat vyvolané bytosti?"
+            },
+            "rerouteAllToGmSocket": {
+                "Hint": "Všechna rozhodnutí provádí PJ místo hráčů, což se hodí v některých hybridních hrách se společným zobrazením.",
+                "Name": "Přesměrovat požadované hody a výběry z dialogu do PJ"
             },
             "quickConditions": {
                 "Hint": "Zaškrtnutí přidá tlačítko do polí 'Podmínky' a 'Podmínky aktivního efektu' v záložce Midi aktivit, které otevírá rozhraní rychlých podmínek.",

--- a/lang/en.json
+++ b/lang/en.json
@@ -3617,8 +3617,8 @@
                 "Name": "Player Selects Conjures"
             },
             "rerouteAllToGmSocket": {
-                "Hint": "GM executes every digital choice instead of player – for hands-off hybrid play with a communal display.",
-                "Name": "Reroute Requested Rolls and Dialog Selections to GM"
+                "Hint": "GM executes every requested digital choice instead of the player – for hands-off hybrid play with a communal display.",
+                "Name": "Reroute Requested Dialogs and Item Uses to GM"
             },
             "quickConditions": {
                 "Hint": "Adds a button to the Use Condition and Active Effect Condition fields on the midi tab on activities which opens a quick condition interface.",

--- a/lang/en.json
+++ b/lang/en.json
@@ -3616,6 +3616,10 @@
                 "Hint": "When casting \"Conjure X\" spells, the player (not the GM) can select which creatures to conjure.",
                 "Name": "Player Selects Conjures"
             },
+            "rerouteAllToGmSocket": {
+                "Hint": "GM executes every digital choice instead of player – for hands-off hybrid play with a communal display.",
+                "Name": "Reroute Requested Rolls and Dialog Selections to GM"
+            },
             "quickConditions": {
                 "Hint": "Adds a button to the Use Condition and Active Effect Condition fields on the midi tab on activities which opens a quick condition interface.",
                 "Name": "Quick Conditions"

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -2648,6 +2648,10 @@
                 "Hint": "Lors du lancement de sorts \"Conjure X\", le joueur (et non le MJ) peut sélectionner les créatures à convoquer.",
                 "Name": "Le Joueur Sélectionne les Conjurations"
             },
+            "rerouteAllToGmSocket": {
+                "Hint": "Le MJ effectue tous les choix à la place des joueurs, ce qui est utile dans certains jeux hybrides avec un affichage commun.",
+                "Name": "Réorienter les Jets de dés et les Choix de Dialogues Demandés vers le MJ"
+            },
             "replaceStatusEffectIcons": {
                 "Hint": "Lorsqu'il est activé, les icônes de statut seront remplacées.",
                 "Name": "Remplacer les Icônes de Statut"

--- a/lang/it.json
+++ b/lang/it.json
@@ -2807,6 +2807,10 @@
                 "Hint": "Quando lancia incantesimi \"Evoca X\", il giocatore (non il DM) può selezionare le creature da evocare.",
                 "Name": "Giocatore Seleziona Evocazioni"
             },
+            "rerouteAllToGmSocket": {
+                "Hint": "Il DM mette in atto tutte le scelte al posto dei giocatori, il che risulta utile in alcune forme di gioco ibride con visualizzazione collettiva.",
+                "Name": "Reindirizza i Tiri di Dado e le Selezioni di Dialogo Richiesti al DM"
+            },
             "replaceStatusEffectIcons": {
                 "Hint": "Quando abilitato, le icone di stato verranno sostituite.",
                 "Name": "Sostituisci Icone di Stato"

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -3478,6 +3478,10 @@
                 "Hint": "Ao conjurar magias do tipo \"Conjurar X\", o jogador (não o Mestre) pode selecionar quais criaturas conjurar.",
                 "Name": "Jogador Escolhe Conjurações"
             },
+            "rerouteAllToGmSocket": {
+                "Hint": "O Mestre executa todas as escolhas em vez dos jogadores, o que é útil em alguns jogos híbridos com uma tela compartilhada.",
+                "Name": "Redirecione as Seleções de Rolagem e Diálogo Solicitadas para o Mestre"
+            },
             "quickConditions": {
                 "Hint": "Adiciona um botão aos campos Condição de Uso e Condição de Efeito Ativo na aba do Midi-QOL em atividades, que abre uma interface de condição rápida.",
                 "Name": "Condições Rápidas"

--- a/scripts/lib/utilities/socketUtils.js
+++ b/scripts/lib/utilities/socketUtils.js
@@ -2,7 +2,7 @@ import {socket, sockets} from '../sockets.js';
 import {genericUtils} from '../../utils.js';
 function gmID() {
     let gmID = game.settings.get('chris-premades', 'gmID');
-    let preferredGMId = game.settings.get('midi-qol', 'PreferredGM');  
+    let preferredGMId = game.settings.get('midi-qol', 'PreferredGM');
     if (preferredGMId !== '') {
         let preferredGM = game.users.get(preferredGMId);
         if (preferredGM?.active) gmID = preferredGM.id;
@@ -19,13 +19,16 @@ function hasPermission(entity, userId) {
 }
 function firstOwner(document, useId) {
     if (!document) return;
-    let corrected = document instanceof TokenDocument ? document.actor : document instanceof foundry.canvas.placeables.Token ? document.document.actor : document;
-    let permissions = genericUtils.getProperty(corrected ?? {}, 'ownership') ?? {};
-    let playerOwners = Object.entries(permissions).filter(([id, level]) => !game.users.get(id)?.isGM && game.users.get(id)?.active && level === 3).map(([id]) => id);
-    if (playerOwners.length > 0) return useId ? playerOwners[0] : game.users.get(playerOwners[0]);
+    if (!genericUtils.getCPRSetting("rerouteAllToGmSocket")) {
+        let corrected = document instanceof TokenDocument ? document.actor : document instanceof foundry.canvas.placeables.Token ? document.document.actor : document;
+        let permissions = genericUtils.getProperty(corrected ?? {}, 'ownership') ?? {};
+        let playerOwners = Object.entries(permissions).filter(([id, level]) => !game.users.get(id)?.isGM && game.users.get(id)?.active && level === 3).map(([id]) => id);
+        if (playerOwners.length > 0) return useId ? playerOwners[0] : game.users.get(playerOwners[0]);
+    }
     return useId ? gmID() : game.users.get(gmID());
 }
 async function remoteRollItem(item, config, options, userId) {
+    if (genericUtils.getCPRSetting("rerouteAllToGmSocket")) userId = gmID();
     if (game.user.id === userId) return await MidiQOL.completeItemUse(item, config, options);
     return await socket.executeAsUser(sockets.rollItem.name, userId, item.uuid, config, options);
 }

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -495,6 +495,12 @@ export function registerSettings() {
         category: 'mechanics'
     });
     addSetting({
+        key: 'rerouteAllToGmSocket',
+        type: Boolean,
+        default: false,
+        category: 'mechanics'
+    });
+    addSetting({
         key: 'lastUpdateCheck',
         type: Number,
         default: 0,


### PR DESCRIPTION
When an orc goes down then CPR asks the player through socketlib whether they want to use Relentless Endurance. This is a great  sensible default for most common ways of playing. However, it does not work for hands-off hybrid play.
Hybrid play happens in-person, but involves a communal screen where the players see Foundry. The communal client shows a map that is in line with what all the player characters would see (Monk's Common Display is often used). Hands-off hybrid play means that the players do not directly interact with Foundry, instead the players tell the GM what they want their PC to do and the GM makes it all happen from their Gamemaster client. The communal client just shows the diegetic location with minimal to no UI elements. Though players often retain the rolling of dice, physically, so a manual roll resolver is used, but the GM enters the results for the players.

Now back to the orc.
https://github.com/chrisk123999/chris-premades/blob/26cd20368456abf0a84cec5d1627cbfbe63af587/scripts/macros/2014/raceFeatures/orc/relentlessEndurance.js#L6
When the orc goes down CPR shows the dialog "Use Relentless Endurance" on the communal players' client, which does not work for this hands-off use case, because the communal client is for viewing only, not for interacting. This PR enables that dialog, and others like it, to be rerouted to the Gamemaster client instead of the communal client, so that the GM could be the only one to deal with Foundry.

Sometimes "rolling" items are requested from the players by CPR also. 
https://github.com/chrisk123999/chris-premades/blob/26cd20368456abf0a84cec5d1627cbfbe63af587/scripts/macros/2014/spells/magicMissile.js#L49
For instance, if a PC is targeted by Magic Missile and they have Shield then the player user is asked if they want to "roll" Shield in order to not be hit by Magic Missile. This PR enables rerouting such item "roll" choices to the GM as well, so that the players could remain immersed in the fiction.

Of course, rerouting socketlib requests to the GM is all behind a (new) setting, which is disabled by default. So nothing changes for people who do not care about hands-off hybrid play. (The non-English setting names and hints are from Google Translate.)