### PR TITLE
DDBI Compatibility - Fisticuffs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - This is not a V14 update. An update for V14 is still a work in progress.
 ## Bug Fixes:
 - Iron Chin
+- Fisticuffs
 
 # 1.5.34 Release:
 ## Update Notes:

--- a/scripts/macros/2024/classFeatures/pugilist/fisticuffs.js
+++ b/scripts/macros/2024/classFeatures/pugilist/fisticuffs.js
@@ -129,9 +129,9 @@ export let fisticuffs = {
                 requiredRace: null,
                 requiredEquipment: [],
                 requiredFeatures: [],
-                replacedItemName: 'Unarmed Strike (Pugilist)',
+                replacedItemName: {name: 'Fisticuffs', type: 'feat', featType: 'class'},
                 removedItems: [],
-                additionalItems: ['Fisticuffs'],
+                additionalItems: [],
                 priority: 0
             }
         }

--- a/scripts/macros/2024/classFeatures/pugilist/fisticuffs.js
+++ b/scripts/macros/2024/classFeatures/pugilist/fisticuffs.js
@@ -119,5 +119,21 @@ export let fisticuffs = {
                 title: 'Fisticuffs'
             }
         } 
-    ]
+    ],
+    ddbi: {
+        restrictedItems: {
+            Fisticuffs: {
+                originalName: 'Fisticuffs',
+                requiredClass: null,
+                requiredSubclass: null,
+                requiredRace: null,
+                requiredEquipment: [],
+                requiredFeatures: [],
+                replacedItemName: 'Unarmed Strike (Pugilist)',
+                removedItems: [],
+                additionalItems: ['Fisticuffs'],
+                priority: 0
+            }
+        }
+    }
 };


### PR DESCRIPTION
Pending MrPrimate/ddb-importer#579, the following has been changed:
- `ddbi.additionalItems` and `ddbi.restrictedItems.additionalItems` now accept an options object containing strings: 
  - `{name, type}`
- `ddbi.restrictedItems.replacedItemName`:
  - `{name, type, featType}`
  
These options can be used when a DDBI item is imported as a different type than its CPR premade item.